### PR TITLE
fix(all): Rename namespace to sphinx-labs

### DIFF
--- a/.changeset/long-plums-yawn.md
+++ b/.changeset/long-plums-yawn.md
@@ -1,0 +1,9 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/executor': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+'@sphinx-labs/demo': patch
+---
+
+Include readme in release

--- a/.changeset/sharp-vans-invite.md
+++ b/.changeset/sharp-vans-invite.md
@@ -1,0 +1,9 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/executor': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+'@sphinx-labs/demo': patch
+---
+
+Rename scope to sphinx-labs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           version: nightly
 
       - name: Build
-        run: yarn build
+        run: yarn build:release
 
       - name: Publish to NPM
         uses: changesets/action@v1

--- a/docs/cli-foundry-existing-project.md
+++ b/docs/cli-foundry-existing-project.md
@@ -41,12 +41,12 @@ You can install Sphinx using Yarn or npm.
 
 Yarn:
 ```
-yarn add --dev @sphinx/plugins
+yarn add --dev @sphinx-labs/plugins
 ```
 
 npm:
 ```
-npm install --save-dev @sphinx/plugins
+npm install --save-dev @sphinx-labs/plugins
 ```
 
 ## 4. Update `forge-std`
@@ -74,15 +74,15 @@ Next, we'll need to add a couple remappings. You probably already have remapping
 
 If you're using a `remappings.txt` file, add:
 ```
-@sphinx/plugins=node_modules/@sphinx/plugins/contracts/foundry/
-@sphinx/contracts=node_modules/@sphinx/contracts/
+@sphinx-labs/plugins=node_modules/@sphinx-labs/plugins/contracts/foundry/
+@sphinx-labs/contracts=node_modules/@sphinx-labs/contracts/
 ```
 
 If your remappings are in `foundry.toml`, update your `remappings` array to include:
 ```
 remappings=[
-  '@sphinx/plugins=node_modules/@sphinx/plugins/contracts/foundry',
-  '@sphinx/contracts=node_modules/@sphinx/contracts/'
+  '@sphinx-labs/plugins=node_modules/@sphinx-labs/plugins/contracts/foundry',
+  '@sphinx-labs/contracts=node_modules/@sphinx-labs/contracts/'
 ]
 ```
 

--- a/docs/cli-foundry-quick-start.md
+++ b/docs/cli-foundry-quick-start.md
@@ -39,12 +39,12 @@ You can install using Yarn or npm.
 
 Yarn:
 ```
-yarn add --dev @sphinx/plugins
+yarn add --dev @sphinx-labs/plugins
 ```
 
 npm:
 ```
-npm install --save-dev @sphinx/plugins
+npm install --save-dev @sphinx-labs/plugins
 ```
 
 ## 4. Initialize project

--- a/docs/cli-hardhat-js-getting-started.md
+++ b/docs/cli-hardhat-js-getting-started.md
@@ -61,19 +61,19 @@ npx hardhat
 
 With Yarn:
 ```
-yarn add --dev @sphinx/plugins
+yarn add --dev @sphinx-labs/plugins
 ```
 With npm:
 ```
-npm install --save-dev @sphinx/plugins
+npm install --save-dev @sphinx-labs/plugins
 ```
 
 ## 6. Update `hardhat.config.js`
 
-You must import `@sphinx/plugins` at the top of your `hardhat.config.js` file:
+You must import `@sphinx-labs/plugins` at the top of your `hardhat.config.js` file:
 
 ```js
-require('@sphinx/plugins')
+require('@sphinx-labs/plugins')
 ```
 
 Next, you must include an `outputSelection` field in the compiler settings of your `hardhat.config.js`. An outline of a Hardhat config is shown for context.

--- a/docs/cli-hardhat-ts-getting-started.md
+++ b/docs/cli-hardhat-ts-getting-started.md
@@ -61,19 +61,19 @@ npx hardhat
 
 With Yarn:
 ```
-yarn add --dev @sphinx/plugins
+yarn add --dev @sphinx-labs/plugins
 ```
 With npm:
 ```
-npm install --save-dev @sphinx/plugins
+npm install --save-dev @sphinx-labs/plugins
 ```
 
 ## 6. Update `hardhat.config.ts`
 
-You must import `@sphinx/plugins` at the top of your `hardhat.config.ts` file:
+You must import `@sphinx-labs/plugins` at the top of your `hardhat.config.ts` file:
 
 ```ts
-import '@sphinx/plugins'
+import '@sphinx-labs/plugins'
 ```
 
 Next, you must include an `outputSelection` field in the compiler settings of your `hardhat.config.ts`. An outline of a Hardhat config is shown for context.

--- a/package.json
+++ b/package.json
@@ -13,20 +13,20 @@
       "packages/demo"
     ],
     "nohoist": [
-      "@sphinx/contracts/@connext/interfaces",
-      "@sphinx/{contracts,plugins}/solmate",
-      "@sphinx/{contracts,plugins}/forge-std",
-      "@sphinx/{contracts,plugins}/ds-test",
-      "@sphinx/{contracts,plugins}/@openzeppelin/contracts",
-      "@sphinx/{contracts,plugins}/@openzeppelin/contracts-upgradeable",
-      "@sphinx/{contracts,plugins}/@eth-optimism/contracts-bedrock",
-      "@sphinx/{contracts,plugins}/@eth-optimism/contracts",
-      "@sphinx/{plugins,demo}/@sphinx/contracts",
-      "@sphinx/{plugins,demo}/forge-std",
-      "@sphinx/{plugins,demo}/ds-test",
-      "@sphinx/plugins/solidity-stringutils",
-      "@sphinx/plugins/@prb/math",
-      "@sphinx/plugins/@layerzerolabs/solidity-examples"
+      "@sphinx-labs/contracts/@connext/interfaces",
+      "@sphinx-labs/{contracts,plugins}/solmate",
+      "@sphinx-labs/{contracts,plugins}/forge-std",
+      "@sphinx-labs/{contracts,plugins}/ds-test",
+      "@sphinx-labs/{contracts,plugins}/@openzeppelin/contracts",
+      "@sphinx-labs/{contracts,plugins}/@openzeppelin/contracts-upgradeable",
+      "@sphinx-labs/{contracts,plugins}/@eth-optimism/contracts-bedrock",
+      "@sphinx-labs/{contracts,plugins}/@eth-optimism/contracts",
+      "@sphinx-labs/{plugins,demo}/@sphinx-labs/contracts",
+      "@sphinx-labs/{plugins,demo}/forge-std",
+      "@sphinx-labs/{plugins,demo}/ds-test",
+      "@sphinx-labs/plugins/solidity-stringutils",
+      "@sphinx-labs/plugins/@prb/math",
+      "@sphinx-labs/plugins/@layerzerolabs/solidity-examples"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     ]
   },
   "scripts": {
+    "build:release": "xargs -n 1 cp -v README.md<<<'./packages/core/ ./packages/plugins/ ./packages/contracts/ ./packages/executor/ ./packages/demo/'",
     "build": "yarn workspaces run build",
     "test": "yarn workspaces run test",
     "clean": "yarn workspaces run clean",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sphinx/contracts
+# @sphinx-labs/contracts
 
 ## 0.9.0
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sphinx/contracts",
+  "name": "@sphinx-labs/contracts",
   "version": "0.9.0",
   "description": "Sphinx contracts",
   "main": "dist/index",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sphinx/core
+# @sphinx-labs/core
 
 ## 0.12.0
 
@@ -27,7 +27,7 @@
 - Updated dependencies [227da3f8]
 - Updated dependencies [1ce34a93]
 - Updated dependencies [21e3702f]
-  - @sphinx/contracts@0.9.0
+  - @sphinx-labs/contracts@0.9.0
 
 ## 0.11.0
 
@@ -38,7 +38,7 @@
 ### Patch Changes
 
 - Updated dependencies [b6d1f76]
-  - @sphinx/contracts@0.8.0
+  - @sphinx-labs/contracts@0.8.0
 
 ## 0.10.1
 
@@ -156,7 +156,7 @@
 - Updated dependencies [f433bc2]
 - Updated dependencies [11fd15c]
 - Updated dependencies [ac40b0b]
-  - @sphinx/contracts@0.7.0
+  - @sphinx-labs/contracts@0.7.0
 
 ## 0.8.1
 
@@ -182,7 +182,7 @@
 - Updated dependencies [3e923a0]
 - Updated dependencies [c76142e]
 - Updated dependencies [35c7a63]
-  - @sphinx/contracts@0.6.0
+  - @sphinx-labs/contracts@0.6.0
 
 ## 0.7.0
 
@@ -201,7 +201,7 @@
 - Updated dependencies [20f1a7e]
 - Updated dependencies [c8af97c]
 - Updated dependencies [736b859]
-  - @sphinx/contracts@0.5.2
+  - @sphinx-labs/contracts@0.5.2
 
 ## 0.6.1
 
@@ -209,7 +209,7 @@
 
 - ca6d384: Bump contracts
 - Updated dependencies [ca6d384]
-  - @sphinx/contracts@0.5.1
+  - @sphinx-labs/contracts@0.5.1
 
 ## 0.6.0
 
@@ -227,7 +227,7 @@
 - Updated dependencies [263b34d]
 - Updated dependencies [fa3f420]
 - Updated dependencies [57a327d]
-  - @sphinx/contracts@0.5.0
+  - @sphinx-labs/contracts@0.5.0
 
 ## 0.5.6
 
@@ -270,7 +270,7 @@
 - Updated dependencies [4265ae4]
 - Updated dependencies [4554d0c]
 - Updated dependencies [591e7da]
-  - @sphinx/contracts@0.4.3
+  - @sphinx-labs/contracts@0.4.3
 
 ## 0.5.0
 
@@ -286,7 +286,7 @@
 - 4029daf: Change `target` to `referenceName` everywhere
 - a37d5c3: Add discord link to output
 - Updated dependencies [4029daf]
-  - @sphinx/contracts@0.4.2
+  - @sphinx-labs/contracts@0.4.2
 
 ## 0.4.2
 
@@ -330,7 +330,7 @@
 - Updated dependencies [60d7adc]
 - Updated dependencies [0443459]
 - Updated dependencies [40f0d0a]
-  - @sphinx/contracts@0.4.0
+  - @sphinx-labs/contracts@0.4.0
 
 ## 0.3.24
 
@@ -338,7 +338,7 @@
 
 - 2267ec4: Bump versions
 - Updated dependencies [2267ec4]
-  - @sphinx/contracts@0.3.17
+  - @sphinx-labs/contracts@0.3.17
 
 ## 0.3.23
 
@@ -357,7 +357,7 @@
 - Updated dependencies [fdf512b]
 - Updated dependencies [88e9465]
 - Updated dependencies [a60020a]
-  - @sphinx/contracts@0.3.16
+  - @sphinx-labs/contracts@0.3.16
 
 ## 0.3.21
 
@@ -370,7 +370,7 @@
 - c9eeb47: Make configPath a normal parameter on all tasks
 - Updated dependencies [74a61c0]
 - Updated dependencies [3ec7a05]
-  - @sphinx/contracts@0.3.15
+  - @sphinx-labs/contracts@0.3.15
 
 ## 0.3.20
 
@@ -384,7 +384,7 @@
 - ba24573: Add list-proposers and add-proposers tasks
 - 276d5ea: Adds function comments to several type checking functions
 - Updated dependencies [c5cf649]
-  - @sphinx/contracts@0.3.14
+  - @sphinx-labs/contracts@0.3.14
 
 ## 0.3.19
 
@@ -397,7 +397,7 @@
 - 2652df5: Fixes circular dependency issue caused by `isContractDeployed`
 - Updated dependencies [7047b9d]
 - Updated dependencies [b55ab15]
-  - @sphinx/contracts@0.3.13
+  - @sphinx-labs/contracts@0.3.13
 
 ## 0.3.18
 
@@ -405,7 +405,7 @@
 
 - e105ea9: Updates Hardhat tasks to reflect proposer/owner requirement
 - Updated dependencies [40c7bfb]
-  - @sphinx/contracts@0.3.12
+  - @sphinx-labs/contracts@0.3.12
 
 ## 0.3.17
 
@@ -417,7 +417,7 @@
 - Updated dependencies [b1850ad]
 - Updated dependencies [e1dc2ec]
 - Updated dependencies [da79232]
-  - @sphinx/contracts@0.3.11
+  - @sphinx-labs/contracts@0.3.11
 
 ## 0.3.16
 
@@ -448,7 +448,7 @@
 - Updated dependencies [6f83489]
 - Updated dependencies [16348b2]
 - Updated dependencies [9be91c3]
-  - @sphinx/contracts@0.3.10
+  - @sphinx-labs/contracts@0.3.10
 
 ## 0.3.15
 
@@ -456,7 +456,7 @@
 
 - 457b19a: Improve sphinx-deploy hardhat task
 - Updated dependencies [ed7babc]
-  - @sphinx/contracts@0.3.9
+  - @sphinx-labs/contracts@0.3.9
 
 ## 0.3.14
 
@@ -482,7 +482,7 @@
 
 - 9d38797: Update sphinx-register task to work locally
 - Updated dependencies [6a6f0c0]
-  - @sphinx/contracts@0.3.8
+  - @sphinx-labs/contracts@0.3.8
 
 ## 0.3.10
 
@@ -495,7 +495,7 @@
 - Updated dependencies [273d4c3]
 - Updated dependencies [c08a950]
 - Updated dependencies [78acb9a]
-  - @sphinx/contracts@0.3.7
+  - @sphinx-labs/contracts@0.3.7
 
 ## 0.3.9
 
@@ -540,7 +540,7 @@
 
 - 123d9c1: Add support for deployments on live networks
 - Updated dependencies [123d9c1]
-  - @sphinx/contracts@0.3.5
+  - @sphinx-labs/contracts@0.3.5
 
 ## 0.3.3
 
@@ -550,7 +550,7 @@
 - 2c5b238: Change config file names
 - 2c5b238: Support demo
 - Updated dependencies [2c5b238]
-  - @sphinx/contracts@0.3.3
+  - @sphinx-labs/contracts@0.3.3
 
 ## 0.3.2
 
@@ -558,7 +558,7 @@
 
 - 03d557c: Bump all versions
 - Updated dependencies [03d557c]
-  - @sphinx/contracts@0.3.2
+  - @sphinx-labs/contracts@0.3.2
 
 ## 0.3.1
 
@@ -567,7 +567,7 @@
 - 557e3bd: Bump versions
 - Updated dependencies [557e3bd]
 - Updated dependencies [cd310fe]
-  - @sphinx/contracts@0.3.1
+  - @sphinx-labs/contracts@0.3.1
 
 ## 0.3.0
 
@@ -578,7 +578,7 @@
 ### Patch Changes
 
 - Updated dependencies [52c7f6c]
-  - @sphinx/contracts@0.3.0
+  - @sphinx-labs/contracts@0.3.0
 
 ## 0.2.1
 
@@ -598,7 +598,7 @@
 - Updated dependencies [416d41b]
 - Updated dependencies [19cf359]
 - Updated dependencies [53e1514]
-  - @sphinx/contracts@0.2.0
+  - @sphinx-labs/contracts@0.2.0
 
 ## 0.1.1
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sphinx/core",
+  "name": "@sphinx-labs/core",
   "version": "0.12.0",
   "description": "Sphinx core library",
   "main": "dist/index",
@@ -39,7 +39,7 @@
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@openzeppelin/merkle-tree": "^1.0.5",
     "@openzeppelin/upgrades-core": "^1.20.6",
-    "@sphinx/contracts": "^0.9.0",
+    "@sphinx-labs/contracts": "^0.9.0",
     "axios": "^1.4.0",
     "chalk": "^4.1.2",
     "core-js": "^3.27.1",

--- a/packages/core/src/actions/artifacts.ts
+++ b/packages/core/src/actions/artifacts.ts
@@ -3,7 +3,7 @@ import {
   ProxyABI,
   ProxyArtifact,
   buildInfo as sphinxBuildInfo,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 
 import {
   ConfigArtifacts,

--- a/packages/core/src/addresses.ts
+++ b/packages/core/src/addresses.ts
@@ -22,7 +22,7 @@ import {
   BalanceArtifact,
   BalanceFactoryArtifact,
   EscrowArtifact,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { constants, utils } from 'ethers'
 
 import { CURRENT_SPHINX_MANAGER_VERSION, REFERENCE_ORG_ID } from './constants'

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -17,7 +17,7 @@ import {
   StorageLayout,
   UpgradeableContractErrorReport,
 } from '@openzeppelin/upgrades-core'
-import { ProxyABI } from '@sphinx/contracts'
+import { ProxyABI } from '@sphinx-labs/contracts'
 import { getDetailedLayout } from '@openzeppelin/upgrades-core/dist/storage/layout'
 import { ContractDefinition, Expression } from 'solidity-ast'
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -6,7 +6,7 @@ import {
   IMPLEMENTATION_TYPE_HASH,
   DEFAULT_PROXY_TYPE_HASH,
   EXTERNAL_TRANSPARENT_PROXY_TYPE_HASH,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { BigNumber, providers } from 'ethers'
 import { CompilerInput } from 'hardhat/types'
 

--- a/packages/core/src/contract-info.ts
+++ b/packages/core/src/contract-info.ts
@@ -18,7 +18,7 @@ import {
   BalanceArtifact,
   EscrowArtifact,
   AuthProxyArtifact,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { constants, providers } from 'ethers/lib/ethers'
 
 import { ContractArtifact } from './languages/solidity/types'

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -21,7 +21,7 @@ import { buildContractUrl } from '@nomiclabs/hardhat-etherscan/dist/src/util'
 import { getLongVersion } from '@nomiclabs/hardhat-etherscan/dist/src/solc/version'
 import { encodeArguments } from '@nomiclabs/hardhat-etherscan/dist/src/ABIEncoder'
 import { chainConfig } from '@nomiclabs/hardhat-etherscan/dist/src/ChainConfig'
-import { buildInfo as sphinxBuildInfo } from '@sphinx/contracts'
+import { buildInfo as sphinxBuildInfo } from '@sphinx-labs/contracts'
 import { request } from 'undici'
 import { CompilerInput } from 'hardhat/types'
 

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_PROXY_TYPE_HASH,
   EXTERNAL_TRANSPARENT_PROXY_TYPE_HASH,
   AuthFactoryABI,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { Logger } from '@eth-optimism/common-ts'
 
 import {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -6,7 +6,7 @@ import { ethers } from 'ethers'
 import ora from 'ora'
 import Hash from 'ipfs-only-hash'
 import { create } from 'ipfs-http-client'
-import { ProxyABI } from '@sphinx/contracts'
+import { ProxyABI } from '@sphinx-labs/contracts'
 
 import {
   SphinxInput,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -24,7 +24,7 @@ import {
   ProxyABI,
   AuthABI,
   AuthFactoryABI,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { TransactionRequest } from '@ethersproject/abstract-provider'
 import { add0x, remove0x } from '@eth-optimism/core-utils'
 import chalk from 'chalk'

--- a/packages/demo/CHANGELOG.md
+++ b/packages/demo/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sphinx/demo
+# @sphinx-labs/demo
 
 ## 0.8.0
 
@@ -31,9 +31,9 @@
 - Updated dependencies [4e6a91e7]
 - Updated dependencies [b93b5a91]
 - Updated dependencies [02a360d9]
-  - @sphinx/plugins@0.17.0
-  - @sphinx/core@0.12.0
-  - @sphinx/contracts@0.9.0
+  - @sphinx-labs/plugins@0.17.0
+  - @sphinx-labs/core@0.12.0
+  - @sphinx-labs/contracts@0.9.0
 
 ## 0.7.0
 
@@ -44,9 +44,9 @@
 ### Patch Changes
 
 - Updated dependencies [b6d1f76]
-  - @sphinx/contracts@0.8.0
-  - @sphinx/plugins@0.16.0
-  - @sphinx/core@0.11.0
+  - @sphinx-labs/contracts@0.8.0
+  - @sphinx-labs/plugins@0.16.0
+  - @sphinx-labs/core@0.11.0
 
 ## 0.6.0
 
@@ -58,8 +58,8 @@
 
 - Updated dependencies [1dafc2c]
 - Updated dependencies [6b975e7]
-  - @sphinx/plugins@0.15.0
-  - @sphinx/core@0.10.0
+  - @sphinx-labs/plugins@0.15.0
+  - @sphinx-labs/core@0.10.0
 
 ## 0.5.0
 
@@ -147,9 +147,9 @@
 - Updated dependencies [ab983d4]
 - Updated dependencies [be43435]
 - Updated dependencies [c69aa51]
-  - @sphinx/core@0.9.0
-  - @sphinx/plugins@0.14.0
-  - @sphinx/contracts@0.7.0
+  - @sphinx-labs/core@0.9.0
+  - @sphinx-labs/plugins@0.14.0
+  - @sphinx-labs/contracts@0.7.0
 
 ## 0.4.5
 
@@ -161,8 +161,8 @@
 - Updated dependencies [3e923a0]
 - Updated dependencies [22c24d2]
 - Updated dependencies [35c7a63]
-  - @sphinx/core@0.8.0
-  - @sphinx/plugins@0.13.0
+  - @sphinx-labs/core@0.8.0
+  - @sphinx-labs/plugins@0.13.0
 
 ## 0.4.4
 
@@ -176,8 +176,8 @@
 - Updated dependencies [80b1a53]
 - Updated dependencies [6a48dd7]
 - Updated dependencies [736b859]
-  - @sphinx/plugins@0.12.0
-  - @sphinx/core@0.7.0
+  - @sphinx-labs/plugins@0.12.0
+  - @sphinx-labs/core@0.7.0
 
 ## 0.4.3
 
@@ -193,8 +193,8 @@
 - Updated dependencies [fa3f420]
 - Updated dependencies [a9d3337]
 - Updated dependencies [57a327d]
-  - @sphinx/core@0.6.0
-  - @sphinx/plugins@0.11.0
+  - @sphinx-labs/core@0.6.0
+  - @sphinx-labs/plugins@0.11.0
 
 ## 0.4.2
 
@@ -202,7 +202,7 @@
 
 - fd98872: Update demo package to reflect latest `getContract` function
 - Updated dependencies [fd98872]
-  - @sphinx/plugins@0.10.5
+  - @sphinx-labs/plugins@0.10.5
 
 ## 0.4.1
 
@@ -217,8 +217,8 @@
 - Updated dependencies [b343641]
 - Updated dependencies [ed17785]
 - Updated dependencies [120327d]
-  - @sphinx/core@0.5.0
-  - @sphinx/plugins@0.10.0
+  - @sphinx-labs/core@0.5.0
+  - @sphinx-labs/plugins@0.10.0
 
 ## 0.4.0
 
@@ -253,8 +253,8 @@
 - Updated dependencies [89fd479]
 - Updated dependencies [40f0d0a]
 - Updated dependencies [2201f3a]
-  - @sphinx/core@0.4.0
-  - @sphinx/plugins@0.9.0
+  - @sphinx-labs/core@0.4.0
+  - @sphinx-labs/plugins@0.9.0
 
 ## 0.3.22
 
@@ -262,8 +262,8 @@
 
 - 2267ec4: Bump versions
 - Updated dependencies [2267ec4]
-  - @sphinx/core@0.3.24
-  - @sphinx/plugins@0.8.9
+  - @sphinx-labs/core@0.3.24
+  - @sphinx-labs/plugins@0.8.9
 
 ## 0.3.21
 
@@ -276,8 +276,8 @@
 - Updated dependencies [fdf512b]
 - Updated dependencies [a60020a]
 - Updated dependencies [64e57d6]
-  - @sphinx/plugins@0.8.6
-  - @sphinx/core@0.3.22
+  - @sphinx-labs/plugins@0.8.6
+  - @sphinx-labs/core@0.3.22
 
 ## 0.3.20
 
@@ -294,8 +294,8 @@
 - Updated dependencies [dba31f7]
 - Updated dependencies [4c04d0a]
 - Updated dependencies [c9eeb47]
-  - @sphinx/core@0.3.21
-  - @sphinx/plugins@0.8.5
+  - @sphinx-labs/core@0.3.21
+  - @sphinx-labs/plugins@0.8.5
 
 ## 0.3.19
 
@@ -314,8 +314,8 @@
 - Updated dependencies [2182a3c]
 - Updated dependencies [276d5ea]
 - Updated dependencies [4b8d25d]
-  - @sphinx/plugins@0.8.4
-  - @sphinx/core@0.3.20
+  - @sphinx-labs/plugins@0.8.4
+  - @sphinx-labs/core@0.3.20
 
 ## 0.3.18
 
@@ -327,8 +327,8 @@
 - Updated dependencies [38c62b5]
 - Updated dependencies [e7ae731]
 - Updated dependencies [2652df5]
-  - @sphinx/core@0.3.19
-  - @sphinx/plugins@0.8.3
+  - @sphinx-labs/core@0.3.19
+  - @sphinx-labs/plugins@0.8.3
 
 ## 0.3.17
 
@@ -342,8 +342,8 @@
 - Updated dependencies [f62dfea]
 - Updated dependencies [bd87e8c]
 - Updated dependencies [d12922d]
-  - @sphinx/core@0.3.17
-  - @sphinx/plugins@0.8.1
+  - @sphinx-labs/core@0.3.17
+  - @sphinx-labs/plugins@0.8.1
 
 ## 0.3.16
 
@@ -390,8 +390,8 @@
 - Updated dependencies [a1ae30f]
 - Updated dependencies [da5cb35]
 - Updated dependencies [5406b7b]
-  - @sphinx/plugins@0.8.0
-  - @sphinx/core@0.3.16
+  - @sphinx-labs/plugins@0.8.0
+  - @sphinx-labs/core@0.3.16
 
 ## 0.3.15
 
@@ -403,8 +403,8 @@
 - Updated dependencies [cf7751d]
 - Updated dependencies [7c367b4]
 - Updated dependencies [457b19a]
-  - @sphinx/plugins@0.7.0
-  - @sphinx/core@0.3.15
+  - @sphinx-labs/plugins@0.7.0
+  - @sphinx-labs/core@0.3.15
 
 ## 0.3.14
 
@@ -412,8 +412,8 @@
 
 - 8323afb: Add deployment artifact generation on the user's side
 - Updated dependencies [8323afb]
-  - @sphinx/plugins@0.6.0
-  - @sphinx/core@0.3.14
+  - @sphinx-labs/plugins@0.6.0
+  - @sphinx-labs/core@0.3.14
 
 ## 0.3.13
 
@@ -421,8 +421,8 @@
 
 - 15ebe78: Hardhat task bug fixes and improvements
 - Updated dependencies [15ebe78]
-  - @sphinx/core@0.3.13
-  - @sphinx/plugins@0.5.14
+  - @sphinx-labs/core@0.3.13
+  - @sphinx-labs/plugins@0.5.14
 
 ## 0.3.12
 
@@ -430,7 +430,7 @@
 
 - b653177: Remove parallel deployments due to bug on live networks
 - Updated dependencies [b653177]
-  - @sphinx/plugins@0.5.13
+  - @sphinx-labs/plugins@0.5.13
 
 ## 0.3.11
 
@@ -443,8 +443,8 @@
 - Updated dependencies [e862925]
 - Updated dependencies [a43e0e3]
 - Updated dependencies [12a7f34]
-  - @sphinx/core@0.3.12
-  - @sphinx/plugins@0.5.12
+  - @sphinx-labs/core@0.3.12
+  - @sphinx-labs/plugins@0.5.12
 
 ## 0.3.10
 
@@ -452,7 +452,7 @@
 
 - 6bc37b3: Bump demo and plugins versions
 - Updated dependencies [6bc37b3]
-  - @sphinx/plugins@0.5.7
+  - @sphinx-labs/plugins@0.5.7
 
 ## 0.3.9
 
@@ -460,7 +460,7 @@
 
 - 86be8a3: Update versions
 - Updated dependencies [86be8a3]
-  - @sphinx/plugins@0.5.5
+  - @sphinx-labs/plugins@0.5.5
 
 ## 0.3.8
 
@@ -475,8 +475,8 @@
 - Updated dependencies [02c7a39]
 - Updated dependencies [6f53f35]
 - Updated dependencies [233f960]
-  - @sphinx/core@0.3.6
-  - @sphinx/plugins@0.5.4
+  - @sphinx-labs/core@0.3.6
+  - @sphinx-labs/plugins@0.5.4
 
 ## 0.3.7
 
@@ -484,7 +484,7 @@
 
 - 6cb309d: Bump versions
 - Updated dependencies [6cb309d]
-  - @sphinx/plugins@0.5.3
+  - @sphinx-labs/plugins@0.5.3
 
 ## 0.3.6
 
@@ -494,8 +494,8 @@
 - dc88439: Improved error handling in deployment task
 - Updated dependencies [3b3ae5a]
 - Updated dependencies [dc88439]
-  - @sphinx/core@0.3.5
-  - @sphinx/plugins@0.5.2
+  - @sphinx-labs/core@0.3.5
+  - @sphinx-labs/plugins@0.5.2
 
 ## 0.3.5
 
@@ -503,7 +503,7 @@
 
 - 8ccbe35: Bump plugins and demo packages
 - Updated dependencies [8ccbe35]
-  - @sphinx/plugins@0.5.1
+  - @sphinx-labs/plugins@0.5.1
 
 ## 0.3.4
 
@@ -511,8 +511,8 @@
 
 - 123d9c1: Add support for deployments on live networks
 - Updated dependencies [123d9c1]
-  - @sphinx/plugins@0.5.0
-  - @sphinx/core@0.3.4
+  - @sphinx-labs/plugins@0.5.0
+  - @sphinx-labs/core@0.3.4
 
 ## 0.3.3
 
@@ -520,7 +520,7 @@
 
 - ded016a: Update demo readme
 - Updated dependencies [ded016a]
-  - @sphinx/plugins@0.4.4
+  - @sphinx-labs/plugins@0.4.4
 
 ## 0.3.2
 
@@ -532,8 +532,8 @@
 - Updated dependencies [2c5b238]
 - Updated dependencies [2c5b238]
 - Updated dependencies [2285b39]
-  - @sphinx/core@0.3.3
-  - @sphinx/plugins@0.4.3
+  - @sphinx-labs/core@0.3.3
+  - @sphinx-labs/plugins@0.4.3
 
 ## 0.3.1
 
@@ -541,8 +541,8 @@
 
 - 03d557c: Bump all versions
 - Updated dependencies [03d557c]
-  - @sphinx/core@0.3.2
-  - @sphinx/plugins@0.4.2
+  - @sphinx-labs/core@0.3.2
+  - @sphinx-labs/plugins@0.4.2
 
 ## 0.3.0
 
@@ -553,8 +553,8 @@
 ### Patch Changes
 
 - Updated dependencies [52c7f6c]
-  - @sphinx/core@0.3.0
-  - @sphinx/plugins@0.4.0
+  - @sphinx-labs/core@0.3.0
+  - @sphinx-labs/plugins@0.4.0
 
 ## 0.2.0
 
@@ -565,8 +565,8 @@
 ### Patch Changes
 
 - Updated dependencies [19cf359]
-  - @sphinx/core@0.2.0
-  - @sphinx/plugins@0.3.0
+  - @sphinx-labs/core@0.2.0
+  - @sphinx-labs/plugins@0.3.0
 
 ## 0.1.1
 
@@ -574,5 +574,5 @@
 
 - Updated dependencies [3a7b19c]
 - Updated dependencies [04ada98]
-  - @sphinx/plugins@0.2.0
-  - @sphinx/core@0.1.1
+  - @sphinx-labs/plugins@0.2.0
+  - @sphinx-labs/core@0.1.1

--- a/packages/demo/foundry.toml
+++ b/packages/demo/foundry.toml
@@ -7,8 +7,8 @@ fs_permissions = [{ access = "read", path = "/"}]
 allow_paths = ["../.."]
 
 remappings=[
-  '@sphinx/plugins=../../node_modules/@sphinx/plugins/contracts/foundry',
-  '@sphinx/contracts=node_modules/@sphinx/contracts/',
+  '@sphinx-labs/plugins=../../node_modules/@sphinx-labs/plugins/contracts/foundry',
+  '@sphinx-labs/contracts=node_modules/@sphinx-labs/contracts/',
   'forge-std/=node_modules/forge-std/src/',
   'ds-test/=node_modules/ds-test/src/'
 ]

--- a/packages/demo/hardhat.config.ts
+++ b/packages/demo/hardhat.config.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv'
 
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
-import '@sphinx/plugins'
+import '@sphinx-labs/plugins'
 
 // Load environment variables from .env
 dotenv.config()

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@sphinx/demo",
+  "name": "@sphinx-labs/demo",
   "version": "0.8.0",
   "description": "Sphinx demo",
   "main": "dist/index",
@@ -43,9 +43,9 @@
     "solhint-plugin-prettier": "^0.0.5"
   },
   "dependencies": {
-    "@sphinx/contracts": "^0.9.0",
-    "@sphinx/core": "^0.12.0",
-    "@sphinx/plugins": "^0.17.0",
+    "@sphinx-labs/contracts": "^0.9.0",
+    "@sphinx-labs/core": "^0.12.0",
+    "@sphinx-labs/plugins": "^0.17.0",
     "@types/node": "^18.0.0",
     "ds-test": "https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#66bf4e2c92cf507531599845e8d5a08cc2e3b5bb",

--- a/packages/demo/test/InitTask.spec.ts
+++ b/packages/demo/test/InitTask.spec.ts
@@ -6,13 +6,13 @@ import {
   execAsync,
   getSphinxManagerAddress,
   getTargetAddress,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import {
   foundryTestFileName,
   sampleContractFileName,
   sampleConfigFileNameTypeScript,
   hhTestFileNameTypeScript,
-} from '@sphinx/plugins'
+} from '@sphinx-labs/plugins'
 import { expect } from 'chai'
 import { sphinx } from 'hardhat'
 import '@nomiclabs/hardhat-ethers'

--- a/packages/executor/CHANGELOG.md
+++ b/packages/executor/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sphinx/executor
+# @sphinx-labs/executor
 
 ## 0.12.0
 
@@ -31,8 +31,8 @@
 - Updated dependencies [4e6a91e7]
 - Updated dependencies [b93b5a91]
 - Updated dependencies [02a360d9]
-  - @sphinx/plugins@0.17.0
-  - @sphinx/core@0.12.0
+  - @sphinx-labs/plugins@0.17.0
+  - @sphinx-labs/core@0.12.0
 
 ## 0.11.0
 
@@ -43,8 +43,8 @@
 ### Patch Changes
 
 - Updated dependencies [b6d1f76]
-  - @sphinx/plugins@0.16.0
-  - @sphinx/core@0.11.0
+  - @sphinx-labs/plugins@0.16.0
+  - @sphinx-labs/core@0.11.0
 
 ## 0.10.0
 
@@ -56,8 +56,8 @@
 
 - Updated dependencies [1dafc2c]
 - Updated dependencies [6b975e7]
-  - @sphinx/plugins@0.15.0
-  - @sphinx/core@0.10.0
+  - @sphinx-labs/plugins@0.15.0
+  - @sphinx-labs/core@0.10.0
 
 ## 0.9.0
 
@@ -139,8 +139,8 @@
 - Updated dependencies [ab983d4]
 - Updated dependencies [be43435]
 - Updated dependencies [c69aa51]
-  - @sphinx/core@0.9.0
-  - @sphinx/plugins@0.14.0
+  - @sphinx-labs/core@0.9.0
+  - @sphinx-labs/plugins@0.14.0
 
 ## 0.8.1
 
@@ -150,7 +150,7 @@
 - 6b3e2ed: Fix contract verification constructor args
 - Updated dependencies [6b3e2ed]
 - Updated dependencies [6b3e2ed]
-  - @sphinx/core@0.8.1
+  - @sphinx-labs/core@0.8.1
 
 ## 0.8.0
 
@@ -169,7 +169,7 @@
 - Updated dependencies [3e923a0]
 - Updated dependencies [22c24d2]
 - Updated dependencies [35c7a63]
-  - @sphinx/core@0.8.0
+  - @sphinx-labs/core@0.8.0
 
 ## 0.7.0
 
@@ -186,7 +186,7 @@
 - Updated dependencies [80b1a53]
 - Updated dependencies [6a48dd7]
 - Updated dependencies [736b859]
-  - @sphinx/core@0.7.0
+  - @sphinx-labs/core@0.7.0
 
 ## 0.6.1
 
@@ -194,7 +194,7 @@
 
 - ca6d384: Bump contracts
 - Updated dependencies [ca6d384]
-  - @sphinx/core@0.6.1
+  - @sphinx-labs/core@0.6.1
 
 ## 0.6.0
 
@@ -212,7 +212,7 @@
 - Updated dependencies [263b34d]
 - Updated dependencies [fa3f420]
 - Updated dependencies [57a327d]
-  - @sphinx/core@0.6.0
+  - @sphinx-labs/core@0.6.0
 
 ## 0.5.5
 
@@ -220,7 +220,7 @@
 
 - 2caf51e: Change minimum compiler input logic to fix bug that generated incomplete inputs
 - Updated dependencies [2caf51e]
-  - @sphinx/core@0.5.5
+  - @sphinx-labs/core@0.5.5
 
 ## 0.5.4
 
@@ -240,7 +240,7 @@
 - Updated dependencies [4029daf]
 - Updated dependencies [a37d5c3]
 - Updated dependencies [b343641]
-  - @sphinx/core@0.5.0
+  - @sphinx-labs/core@0.5.0
 
 ## 0.5.2
 
@@ -254,7 +254,7 @@
 
 - 48088b2: Add timeout on analytics functions
 - Updated dependencies [48088b2]
-  - @sphinx/core@0.4.1
+  - @sphinx-labs/core@0.4.1
 
 ## 0.5.0
 
@@ -291,7 +291,7 @@
 - Updated dependencies [0443459]
 - Updated dependencies [40f0d0a]
 - Updated dependencies [2201f3a]
-  - @sphinx/core@0.4.0
+  - @sphinx-labs/core@0.4.0
 
 ## 0.4.14
 
@@ -299,7 +299,7 @@
 
 - 2267ec4: Bump versions
 - Updated dependencies [2267ec4]
-  - @sphinx/core@0.3.24
+  - @sphinx-labs/core@0.3.24
 
 ## 0.4.13
 
@@ -309,7 +309,7 @@
 - d6984ec: Override transaction gas prices to use EIP-1559 if supported by the network
 - 532d586: Support defining executor port with environment variable
 - Updated dependencies [d6984ec]
-  - @sphinx/core@0.3.23
+  - @sphinx-labs/core@0.3.23
 
 ## 0.4.12
 
@@ -321,7 +321,7 @@
 - Updated dependencies [1cb43e7]
 - Updated dependencies [acfe88d]
 - Updated dependencies [fdf512b]
-  - @sphinx/core@0.3.22
+  - @sphinx-labs/core@0.3.22
 
 ## 0.4.11
 
@@ -335,7 +335,7 @@
 - Updated dependencies [89cd352]
 - Updated dependencies [dba31f7]
 - Updated dependencies [c9eeb47]
-  - @sphinx/core@0.3.21
+  - @sphinx-labs/core@0.3.21
 
 ## 0.4.10
 
@@ -352,7 +352,7 @@
 - Updated dependencies [335dfc7]
 - Updated dependencies [ba24573]
 - Updated dependencies [276d5ea]
-  - @sphinx/core@0.3.20
+  - @sphinx-labs/core@0.3.20
 
 ## 0.4.9
 
@@ -366,7 +366,7 @@
 - Updated dependencies [38c62b5]
 - Updated dependencies [e7ae731]
 - Updated dependencies [2652df5]
-  - @sphinx/core@0.3.19
+  - @sphinx-labs/core@0.3.19
 
 ## 0.4.8
 
@@ -376,7 +376,7 @@
 - 7e8dd1e: Removes the projectOwner from the Sphinx config
 - Updated dependencies [d7fff20]
 - Updated dependencies [7e8dd1e]
-  - @sphinx/core@0.3.17
+  - @sphinx-labs/core@0.3.17
 
 ## 0.4.7
 
@@ -414,7 +414,7 @@
 - Updated dependencies [ec41164]
 - Updated dependencies [da5cb35]
 - Updated dependencies [5406b7b]
-  - @sphinx/core@0.3.16
+  - @sphinx-labs/core@0.3.16
 
 ## 0.4.6
 

--- a/packages/executor/hardhat.config.ts
+++ b/packages/executor/hardhat.config.ts
@@ -2,7 +2,7 @@ import { HardhatUserConfig } from 'hardhat/types'
 
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
-import '@sphinx/plugins'
+import '@sphinx-labs/plugins'
 
 const config: HardhatUserConfig = {
   mocha: {
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
       // This must be the chain ID of a live network that Sphinx supports. This allows us to
       // test the remote executor against a Sphinx config, which can only contain supported live
       // networks. For a list of supported networks, see the `SUPPORTED_NETWORKS` object in the
-      // `@sphinx/core` package.
+      // `@sphinx-labs/core` package.
       chainId: 5,
     },
   },

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sphinx/executor",
+  "name": "@sphinx-labs/executor",
   "version": "0.12.0",
   "description": "Sphinx deployment execution bot",
   "main": "dist/index",
@@ -35,8 +35,8 @@
     "url": "https://github.com/smartcontracts/sphinx.git"
   },
   "devDependencies": {
-    "@sphinx/contracts": "^0.9.0",
-    "@sphinx/core": "^0.12.0",
+    "@sphinx-labs/contracts": "^0.9.0",
+    "@sphinx-labs/core": "^0.12.0",
     "@eth-optimism/common-ts": "^0.7.1",
     "@eth-optimism/core-utils": "^0.9.3",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
@@ -48,8 +48,8 @@
   },
   "dependencies": {
     "@amplitude/node": "^1.10.2",
-    "@sphinx/core": "^0.12.0",
-    "@sphinx/plugins": "^0.17.0",
+    "@sphinx-labs/core": "^0.12.0",
+    "@sphinx-labs/plugins": "^0.17.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.3",
     "chai": "^4.3.7",
     "graphql": "^16.6.0",

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -9,7 +9,7 @@ import {
   validators,
 } from '@eth-optimism/common-ts'
 import { ethers } from 'ethers'
-import { SphinxRegistryABI } from '@sphinx/contracts'
+import { SphinxRegistryABI } from '@sphinx-labs/contracts'
 import {
   getSphinxRegistryAddress,
   ExecutorOptions,
@@ -18,7 +18,7 @@ import {
   ExecutorEvent,
   ExecutorKey,
   ensureSphinxInitialized,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { GraphQLClient } from 'graphql-request'
 
 import { ExecutorMessage, ResponseMessage } from './utils/execute'

--- a/packages/executor/src/utils/execute.ts
+++ b/packages/executor/src/utils/execute.ts
@@ -1,6 +1,6 @@
 import * as dotenv from 'dotenv'
 dotenv.config()
-import { ManagedServiceABI, SphinxManagerABI } from '@sphinx/contracts'
+import { ManagedServiceABI, SphinxManagerABI } from '@sphinx-labs/contracts'
 import {
   DeploymentState,
   compileRemoteBundles,
@@ -18,7 +18,7 @@ import {
   ConfigArtifacts,
   estimateExecutionCost,
   getManagedServiceAddress,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { Logger, LogLevel, LoggerOptions } from '@eth-optimism/common-ts'
 import { ethers } from 'ethers'
 import { GraphQLClient } from 'graphql-request'

--- a/packages/executor/test/Executor.spec.ts
+++ b/packages/executor/test/Executor.spec.ts
@@ -1,5 +1,5 @@
 import hre from 'hardhat'
-import '@sphinx/plugins'
+import '@sphinx-labs/plugins'
 import '@nomiclabs/hardhat-ethers'
 import {
   AUTH_FACTORY_ADDRESS,
@@ -20,10 +20,14 @@ import {
   getTargetAddress,
   monitorExecution,
   sphinxCommitAbstractSubtask,
-} from '@sphinx/core'
-import { AuthFactoryABI, AuthABI, SphinxManagerABI } from '@sphinx/contracts'
-import { createSphinxRuntime } from '@sphinx/plugins/src/cre'
-import { makeGetConfigArtifacts } from '@sphinx/plugins/src/hardhat/artifacts'
+} from '@sphinx-labs/core'
+import {
+  AuthFactoryABI,
+  AuthABI,
+  SphinxManagerABI,
+} from '@sphinx-labs/contracts'
+import { createSphinxRuntime } from '@sphinx-labs/plugins/src/cre'
+import { makeGetConfigArtifacts } from '@sphinx-labs/plugins/src/hardhat/artifacts'
 import { expect } from 'chai'
 import { Contract, ethers } from 'ethers'
 

--- a/packages/plugins/.gitignore
+++ b/packages/plugins/.gitignore
@@ -15,7 +15,7 @@ out/
 dist/
 tsconfig.tsbuildinfo
 
-node_modules/@sphinx
+node_modules/@sphinx-labs
 .openzeppelin/*
 
 broadcast/

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sphinx/plugins
+# @sphinx-labs/plugins
 
 ## 0.17.0
 
@@ -38,8 +38,8 @@
 - Updated dependencies [c53f22dd]
 - Updated dependencies [b93b5a91]
 - Updated dependencies [02a360d9]
-  - @sphinx/core@0.12.0
-  - @sphinx/contracts@0.9.0
+  - @sphinx-labs/core@0.12.0
+  - @sphinx-labs/contracts@0.9.0
 
 ## 0.16.5
 
@@ -61,7 +61,7 @@
 - 8d2bf40: Fix issues with sample project generation
 - 586c823: Minimize size of Sphinx.sol and allow Solidity versions >= 0.7.4
 - Updated dependencies [586c823]
-  - @sphinx/contracts@0.8.2
+  - @sphinx-labs/contracts@0.8.2
 
 ## 0.16.2
 
@@ -69,7 +69,7 @@
 
 - 60d60bc: Specify compiler version range for foundry library contracts
 - Updated dependencies [60d60bc]
-  - @sphinx/contracts@0.8.1
+  - @sphinx-labs/contracts@0.8.1
 
 ## 0.16.1
 
@@ -86,8 +86,8 @@
 ### Patch Changes
 
 - Updated dependencies [b6d1f76]
-  - @sphinx/contracts@0.8.0
-  - @sphinx/core@0.11.0
+  - @sphinx-labs/contracts@0.8.0
+  - @sphinx-labs/core@0.11.0
 
 ## 0.15.1
 
@@ -95,7 +95,7 @@
 
 - f13070f: Use Optimism contracts-bedrock package canary version in all Sphinx packages
 - Updated dependencies [f13070f]
-  - @sphinx/core@0.10.1
+  - @sphinx-labs/core@0.10.1
 
 ## 0.15.0
 
@@ -108,7 +108,7 @@
 - 1dafc2c: Add support for mapping keys that are contract or enum types
 - Updated dependencies [1dafc2c]
 - Updated dependencies [6b975e7]
-  - @sphinx/core@0.10.0
+  - @sphinx-labs/core@0.10.0
 
 ## 0.14.1
 
@@ -232,8 +232,8 @@
 - Updated dependencies [ab983d4]
 - Updated dependencies [be43435]
 - Updated dependencies [c69aa51]
-  - @sphinx/core@0.9.0
-  - @sphinx/contracts@0.7.0
+  - @sphinx-labs/core@0.9.0
+  - @sphinx-labs/contracts@0.7.0
 
 ## 0.13.0
 
@@ -253,9 +253,9 @@
 - Updated dependencies [c76142e]
 - Updated dependencies [22c24d2]
 - Updated dependencies [35c7a63]
-  - @sphinx/core@0.8.0
-  - @sphinx/contracts@0.6.0
-  - @sphinx/executor@0.8.0
+  - @sphinx-labs/core@0.8.0
+  - @sphinx-labs/contracts@0.6.0
+  - @sphinx-labs/executor@0.8.0
 
 ## 0.12.0
 
@@ -277,9 +277,9 @@
 - Updated dependencies [80b1a53]
 - Updated dependencies [6a48dd7]
 - Updated dependencies [736b859]
-  - @sphinx/core@0.7.0
-  - @sphinx/contracts@0.5.2
-  - @sphinx/executor@0.7.0
+  - @sphinx-labs/core@0.7.0
+  - @sphinx-labs/contracts@0.5.2
+  - @sphinx-labs/executor@0.7.0
 
 ## 0.11.1
 
@@ -288,9 +288,9 @@
 - d30ebdf: Change the task for displaying bundles into a script
 - ca6d384: Bump contracts
 - Updated dependencies [ca6d384]
-  - @sphinx/contracts@0.5.1
-  - @sphinx/core@0.6.1
-  - @sphinx/executor@0.6.1
+  - @sphinx-labs/contracts@0.5.1
+  - @sphinx-labs/core@0.6.1
+  - @sphinx-labs/executor@0.6.1
 
 ## 0.11.0
 
@@ -313,9 +313,9 @@
 - Updated dependencies [263b34d]
 - Updated dependencies [fa3f420]
 - Updated dependencies [57a327d]
-  - @sphinx/executor@0.6.0
-  - @sphinx/core@0.6.0
-  - @sphinx/contracts@0.5.0
+  - @sphinx-labs/executor@0.6.0
+  - @sphinx-labs/core@0.6.0
+  - @sphinx-labs/contracts@0.5.0
 
 ## 0.10.7
 
@@ -324,7 +324,7 @@
 - c30b8ef: Fix bug caused by logic that gets the minimum compiler input for a bundle
 - Updated dependencies [c30b8ef]
 - Updated dependencies [90e5c0b]
-  - @sphinx/core@0.5.6
+  - @sphinx-labs/core@0.5.6
 
 ## 0.10.6
 
@@ -332,8 +332,8 @@
 
 - 2caf51e: Change minimum compiler input logic to fix bug that generated incomplete inputs
 - Updated dependencies [2caf51e]
-  - @sphinx/executor@0.5.5
-  - @sphinx/core@0.5.5
+  - @sphinx-labs/executor@0.5.5
+  - @sphinx-labs/core@0.5.5
 
 ## 0.10.5
 
@@ -347,7 +347,7 @@
 
 - 4cf40e5: Bump plugins and executor versions
 - Updated dependencies [4cf40e5]
-  - @sphinx/executor@0.5.4
+  - @sphinx-labs/executor@0.5.4
 
 ## 0.10.3
 
@@ -355,7 +355,7 @@
 
 - ecfe984: Bump core and plugins versions
 - Updated dependencies [ecfe984]
-  - @sphinx/core@0.5.3
+  - @sphinx-labs/core@0.5.3
 
 ## 0.10.2
 
@@ -374,8 +374,8 @@
 - Updated dependencies [e56b684]
 - Updated dependencies [a892f24]
 - Updated dependencies [fd70a56]
-  - @sphinx/contracts@0.4.3
-  - @sphinx/core@0.5.1
+  - @sphinx-labs/contracts@0.4.3
+  - @sphinx-labs/core@0.5.1
 
 ## 0.10.0
 
@@ -396,9 +396,9 @@
 - Updated dependencies [4029daf]
 - Updated dependencies [a37d5c3]
 - Updated dependencies [b343641]
-  - @sphinx/core@0.5.0
-  - @sphinx/executor@0.5.3
-  - @sphinx/contracts@0.4.2
+  - @sphinx-labs/core@0.5.0
+  - @sphinx-labs/executor@0.5.3
+  - @sphinx-labs/contracts@0.4.2
 
 ## 0.9.0
 
@@ -440,9 +440,9 @@
 - Updated dependencies [0443459]
 - Updated dependencies [40f0d0a]
 - Updated dependencies [2201f3a]
-  - @sphinx/core@0.4.0
-  - @sphinx/executor@0.5.0
-  - @sphinx/contracts@0.4.0
+  - @sphinx-labs/core@0.4.0
+  - @sphinx-labs/executor@0.5.0
+  - @sphinx-labs/contracts@0.4.0
 
 ## 0.8.9
 
@@ -450,9 +450,9 @@
 
 - 2267ec4: Bump versions
 - Updated dependencies [2267ec4]
-  - @sphinx/contracts@0.3.17
-  - @sphinx/core@0.3.24
-  - @sphinx/executor@0.4.14
+  - @sphinx-labs/contracts@0.3.17
+  - @sphinx-labs/core@0.3.24
+  - @sphinx-labs/executor@0.4.14
 
 ## 0.8.8
 
@@ -469,8 +469,8 @@
 - Updated dependencies [7cd5e1b]
 - Updated dependencies [d6984ec]
 - Updated dependencies [532d586]
-  - @sphinx/executor@0.4.13
-  - @sphinx/core@0.3.23
+  - @sphinx-labs/executor@0.4.13
+  - @sphinx-labs/core@0.3.23
 
 ## 0.8.6
 
@@ -487,9 +487,9 @@
 - Updated dependencies [88e9465]
 - Updated dependencies [a60020a]
 - Updated dependencies [64e57d6]
-  - @sphinx/contracts@0.3.16
-  - @sphinx/core@0.3.22
-  - @sphinx/executor@0.4.12
+  - @sphinx-labs/contracts@0.3.16
+  - @sphinx-labs/core@0.3.22
+  - @sphinx-labs/executor@0.4.12
 
 ## 0.8.5
 
@@ -510,9 +510,9 @@
 - Updated dependencies [89cd352]
 - Updated dependencies [dba31f7]
 - Updated dependencies [c9eeb47]
-  - @sphinx/contracts@0.3.15
-  - @sphinx/core@0.3.21
-  - @sphinx/executor@0.4.11
+  - @sphinx-labs/contracts@0.3.15
+  - @sphinx-labs/core@0.3.21
+  - @sphinx-labs/executor@0.4.11
 
 ## 0.8.4
 
@@ -533,9 +533,9 @@
 - Updated dependencies [335dfc7]
 - Updated dependencies [ba24573]
 - Updated dependencies [276d5ea]
-  - @sphinx/contracts@0.3.14
-  - @sphinx/core@0.3.20
-  - @sphinx/executor@0.4.10
+  - @sphinx-labs/contracts@0.3.14
+  - @sphinx-labs/core@0.3.20
+  - @sphinx-labs/executor@0.4.10
 
 ## 0.8.3
 
@@ -551,9 +551,9 @@
 - Updated dependencies [38c62b5]
 - Updated dependencies [e7ae731]
 - Updated dependencies [2652df5]
-  - @sphinx/core@0.3.19
-  - @sphinx/executor@0.4.9
-  - @sphinx/contracts@0.3.13
+  - @sphinx-labs/core@0.3.19
+  - @sphinx-labs/executor@0.4.9
+  - @sphinx-labs/contracts@0.3.13
 
 ## 0.8.2
 
@@ -562,8 +562,8 @@
 - e105ea9: Updates Hardhat tasks to reflect proposer/owner requirement
 - Updated dependencies [40c7bfb]
 - Updated dependencies [e105ea9]
-  - @sphinx/contracts@0.3.12
-  - @sphinx/core@0.3.18
+  - @sphinx-labs/contracts@0.3.12
+  - @sphinx-labs/core@0.3.18
 
 ## 0.8.1
 
@@ -580,9 +580,9 @@
 - Updated dependencies [7e8dd1e]
 - Updated dependencies [e1dc2ec]
 - Updated dependencies [da79232]
-  - @sphinx/contracts@0.3.11
-  - @sphinx/core@0.3.17
-  - @sphinx/executor@0.4.8
+  - @sphinx-labs/contracts@0.3.11
+  - @sphinx-labs/core@0.3.17
+  - @sphinx-labs/executor@0.4.8
 
 ## 0.8.0
 
@@ -651,9 +651,9 @@
 - Updated dependencies [ec41164]
 - Updated dependencies [da5cb35]
 - Updated dependencies [5406b7b]
-  - @sphinx/core@0.3.16
-  - @sphinx/executor@0.4.7
-  - @sphinx/contracts@0.3.10
+  - @sphinx-labs/core@0.3.16
+  - @sphinx-labs/executor@0.4.7
+  - @sphinx-labs/contracts@0.3.10
 
 ## 0.7.0
 
@@ -670,8 +670,8 @@
 - 457b19a: Improve sphinx-deploy hardhat task
 - Updated dependencies [ed7babc]
 - Updated dependencies [457b19a]
-  - @sphinx/contracts@0.3.9
-  - @sphinx/core@0.3.15
+  - @sphinx-labs/contracts@0.3.9
+  - @sphinx-labs/core@0.3.15
 
 ## 0.6.0
 
@@ -682,7 +682,7 @@
 ### Patch Changes
 
 - Updated dependencies [8323afb]
-  - @sphinx/core@0.3.14
+  - @sphinx-labs/core@0.3.14
 
 ## 0.5.14
 
@@ -690,7 +690,7 @@
 
 - 15ebe78: Hardhat task bug fixes and improvements
 - Updated dependencies [15ebe78]
-  - @sphinx/core@0.3.13
+  - @sphinx-labs/core@0.3.13
 
 ## 0.5.13
 
@@ -709,7 +709,7 @@
 - a43e0e3: Add Docker configuration for executor
 - 12a7f34: Improve execution speed with parallelization
 - Updated dependencies [ecafe45]
-  - @sphinx/core@0.3.12
+  - @sphinx-labs/core@0.3.12
 
 ## 0.5.11
 
@@ -721,8 +721,8 @@
 - 9d38797: Update sphinx-register task to work locally
 - Updated dependencies [6a6f0c0]
 - Updated dependencies [9d38797]
-  - @sphinx/contracts@0.3.8
-  - @sphinx/core@0.3.11
+  - @sphinx-labs/contracts@0.3.8
+  - @sphinx-labs/core@0.3.11
 
 ## 0.5.10
 
@@ -744,8 +744,8 @@
 - Updated dependencies [6daea1a]
 - Updated dependencies [c08a950]
 - Updated dependencies [78acb9a]
-  - @sphinx/contracts@0.3.7
-  - @sphinx/core@0.3.10
+  - @sphinx-labs/contracts@0.3.7
+  - @sphinx-labs/core@0.3.10
 
 ## 0.5.9
 
@@ -753,7 +753,7 @@
 
 - 5ad574b: Fixes a bug that would break deterministic deployment on non-hardhat networks
 - Updated dependencies [062a439]
-  - @sphinx/core@0.3.9
+  - @sphinx-labs/core@0.3.9
 
 ## 0.5.8
 
@@ -763,7 +763,7 @@
 - 5e74723: Add support for mappings
 - 138f0cd: Small bug fixes for immutable handling
 - Updated dependencies [5e74723]
-  - @sphinx/core@0.3.8
+  - @sphinx-labs/core@0.3.8
 
 ## 0.5.7
 
@@ -783,7 +783,7 @@
 - Updated dependencies [3a64b82]
 - Updated dependencies [bbe3639]
 - Updated dependencies [1b88270]
-  - @sphinx/core@0.3.7
+  - @sphinx-labs/core@0.3.7
 
 ## 0.5.5
 
@@ -804,7 +804,7 @@
 - Updated dependencies [02c7a39]
 - Updated dependencies [6f53f35]
 - Updated dependencies [233f960]
-  - @sphinx/core@0.3.6
+  - @sphinx-labs/core@0.3.6
 
 ## 0.5.3
 
@@ -820,7 +820,7 @@
 - dc88439: Improved error handling in deployment task
 - Updated dependencies [3b3ae5a]
 - Updated dependencies [dc88439]
-  - @sphinx/core@0.3.5
+  - @sphinx-labs/core@0.3.5
 
 ## 0.5.1
 
@@ -837,8 +837,8 @@
 ### Patch Changes
 
 - Updated dependencies [123d9c1]
-  - @sphinx/contracts@0.3.5
-  - @sphinx/core@0.3.4
+  - @sphinx-labs/contracts@0.3.5
+  - @sphinx-labs/core@0.3.4
 
 ## 0.4.4
 
@@ -855,8 +855,8 @@
 - Updated dependencies [4ce753b]
 - Updated dependencies [2c5b238]
 - Updated dependencies [2c5b238]
-  - @sphinx/core@0.3.3
-  - @sphinx/contracts@0.3.3
+  - @sphinx-labs/core@0.3.3
+  - @sphinx-labs/contracts@0.3.3
 
 ## 0.4.2
 
@@ -864,8 +864,8 @@
 
 - 03d557c: Bump all versions
 - Updated dependencies [03d557c]
-  - @sphinx/contracts@0.3.2
-  - @sphinx/core@0.3.2
+  - @sphinx-labs/contracts@0.3.2
+  - @sphinx-labs/core@0.3.2
 
 ## 0.4.1
 
@@ -874,8 +874,8 @@
 - 557e3bd: Bump versions
 - Updated dependencies [557e3bd]
 - Updated dependencies [cd310fe]
-  - @sphinx/contracts@0.3.1
-  - @sphinx/core@0.3.1
+  - @sphinx-labs/contracts@0.3.1
+  - @sphinx-labs/core@0.3.1
 
 ## 0.4.0
 
@@ -886,8 +886,8 @@
 ### Patch Changes
 
 - Updated dependencies [52c7f6c]
-  - @sphinx/contracts@0.3.0
-  - @sphinx/core@0.3.0
+  - @sphinx-labs/contracts@0.3.0
+  - @sphinx-labs/core@0.3.0
 
 ## 0.3.1
 
@@ -897,7 +897,7 @@
 - f7a4a24: Bump core and plugins packages
 - Updated dependencies [f7a4a24]
 - Updated dependencies [f7a4a24]
-  - @sphinx/core@0.2.1
+  - @sphinx-labs/core@0.2.1
 
 ## 0.3.0
 
@@ -910,8 +910,8 @@
 - Updated dependencies [416d41b]
 - Updated dependencies [19cf359]
 - Updated dependencies [53e1514]
-  - @sphinx/contracts@0.2.0
-  - @sphinx/core@0.2.0
+  - @sphinx-labs/contracts@0.2.0
+  - @sphinx-labs/core@0.2.0
 
 ## 0.2.1
 
@@ -942,8 +942,8 @@
 - Updated dependencies [f92ff76]
 - Updated dependencies [04ada98]
 - Updated dependencies [2cc3bc9]
-  - @sphinx/contracts@0.2.0
-  - @sphinx/core@0.1.1
+  - @sphinx-labs/contracts@0.2.0
+  - @sphinx-labs/core@0.1.1
 
 ## 0.1.2
 
@@ -955,4 +955,4 @@
 - e5fe498: Brings back the SphinxManager contract
 - Updated dependencies [6403ed2]
 - Updated dependencies [e5fe498]
-  - @sphinx/contracts@0.1.1
+  - @sphinx-labs/contracts@0.1.1

--- a/packages/plugins/contracts/foundry/Sphinx.sol
+++ b/packages/plugins/contracts/foundry/Sphinx.sol
@@ -6,9 +6,9 @@ import { Script } from "forge-std/Script.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
 
-import { ISphinxRegistry } from "@sphinx/contracts/contracts/interfaces/ISphinxRegistry.sol";
-import { ISphinxManager } from "@sphinx/contracts/contracts/interfaces/ISphinxManager.sol";
-import { IOwnable } from "@sphinx/contracts/contracts/interfaces/IOwnable.sol";
+import { ISphinxRegistry } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxRegistry.sol";
+import { ISphinxManager } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxManager.sol";
+import { IOwnable } from "@sphinx-labs/contracts/contracts/interfaces/IOwnable.sol";
 import {
     DeploymentState,
     Version,
@@ -19,7 +19,7 @@ import {
     BundledSphinxTarget,
     SphinxActionBundle,
     SphinxTargetBundle
-} from "@sphinx/contracts/contracts/SphinxDataTypes.sol";
+} from "@sphinx-labs/contracts/contracts/SphinxDataTypes.sol";
 import {
     FoundryConfig,
     Configs,
@@ -46,7 +46,7 @@ contract Sphinx is Script {
     address private systemOwnerAddress =
         key != 0 ? vm.rememberKey(key) : 0x226F14C3e19788934Ff37C653Cf5e24caD198341;
 
-    string private rootPath = vm.envOr("DEV_FILE_PATH", string("./node_modules/@sphinx/plugins/"));
+    string private rootPath = vm.envOr("DEV_FILE_PATH", string("./node_modules/@sphinx-labs/plugins/"));
     string private rootFfiPath = string(abi.encodePacked(rootPath, "dist/foundry/"));
     string internal mainFfiScriptPath = string(abi.encodePacked(rootFfiPath, "index.js"));
 

--- a/packages/plugins/contracts/foundry/SphinxPluginTypes.sol
+++ b/packages/plugins/contracts/foundry/SphinxPluginTypes.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.4 <0.9.0;
 import {
     SphinxActionBundle,
     SphinxTargetBundle
-} from "@sphinx/contracts/contracts/SphinxDataTypes.sol";
+} from "@sphinx-labs/contracts/contracts/SphinxDataTypes.sol";
 
 struct Configs {
     FoundryConfig minimalConfig;

--- a/packages/plugins/contracts/foundry/SphinxTasks.sol
+++ b/packages/plugins/contracts/foundry/SphinxTasks.sol
@@ -10,8 +10,8 @@ import {
     FoundryContractConfig,
     ContractKindEnum
 } from "./SphinxPluginTypes.sol";
-import { ISphinxRegistry } from "@sphinx/contracts/contracts/interfaces/ISphinxRegistry.sol";
-import { ISphinxManager } from "@sphinx/contracts/contracts/interfaces/ISphinxManager.sol";
+import { ISphinxRegistry } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxRegistry.sol";
+import { ISphinxManager } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxManager.sol";
 import { SphinxConstants } from "./SphinxConstants.sol";
 
 contract SphinxTasks is Sphinx, SphinxConstants {

--- a/packages/plugins/contracts/foundry/SphinxUtils.sol
+++ b/packages/plugins/contracts/foundry/SphinxUtils.sol
@@ -11,11 +11,11 @@ import { StdStyle } from "forge-std/StdStyle.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-import { ISphinxRegistry } from "@sphinx/contracts/contracts/interfaces/ISphinxRegistry.sol";
-import { ISphinxManager } from "@sphinx/contracts/contracts/interfaces/ISphinxManager.sol";
-import { IOwnable } from "@sphinx/contracts/contracts/interfaces/IOwnable.sol";
-import { SphinxManagerEvents } from "@sphinx/contracts/contracts/SphinxManagerEvents.sol";
-import { SphinxRegistryEvents } from "@sphinx/contracts/contracts/SphinxRegistryEvents.sol";
+import { ISphinxRegistry } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxRegistry.sol";
+import { ISphinxManager } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxManager.sol";
+import { IOwnable } from "@sphinx-labs/contracts/contracts/interfaces/IOwnable.sol";
+import { SphinxManagerEvents } from "@sphinx-labs/contracts/contracts/SphinxManagerEvents.sol";
+import { SphinxRegistryEvents } from "@sphinx-labs/contracts/contracts/SphinxRegistryEvents.sol";
 import {
     SphinxBundles,
     DeploymentState,
@@ -29,8 +29,8 @@ import {
     SphinxTargetBundle,
     BundledSphinxTarget,
     Version
-} from "@sphinx/contracts/contracts/SphinxDataTypes.sol";
-import { SphinxAuthFactory } from "@sphinx/contracts/contracts/SphinxAuthFactory.sol";
+} from "@sphinx-labs/contracts/contracts/SphinxDataTypes.sol";
+import { SphinxAuthFactory } from "@sphinx-labs/contracts/contracts/SphinxAuthFactory.sol";
 import {
     FoundryConfig,
     Configs,

--- a/packages/plugins/contracts/foundry/interfaces/ISphinxUtils.sol
+++ b/packages/plugins/contracts/foundry/interfaces/ISphinxUtils.sol
@@ -3,15 +3,15 @@ pragma solidity >=0.7.4 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import { VmSafe } from "forge-std/Vm.sol";
-import { ISphinxRegistry } from "@sphinx/contracts/contracts/interfaces/ISphinxRegistry.sol";
-import { ISphinxManager } from "@sphinx/contracts/contracts/interfaces/ISphinxManager.sol";
+import { ISphinxRegistry } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxRegistry.sol";
+import { ISphinxManager } from "@sphinx-labs/contracts/contracts/interfaces/ISphinxManager.sol";
 import {
     Version,
     SphinxActionBundle,
     BundledSphinxAction,
     RawSphinxAction,
     SphinxTargetBundle
-} from "@sphinx/contracts/contracts/SphinxDataTypes.sol";
+} from "@sphinx-labs/contracts/contracts/SphinxDataTypes.sol";
 import {
     ConfigCache,
     DeployContractCost,

--- a/packages/plugins/contracts/test/Stateless.sol
+++ b/packages/plugins/contracts/test/Stateless.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import { Version } from "@sphinx/contracts/contracts/SphinxDataTypes.sol";
+import { Version } from "@sphinx-labs/contracts/contracts/SphinxDataTypes.sol";
 
 contract Stateless {
     uint public immutable immutableUint;

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sphinx/plugins",
+  "name": "@sphinx-labs/plugins",
   "version": "0.17.0",
   "description": "Sphinx plugins",
   "main": "dist/index",
@@ -49,8 +49,8 @@
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@openzeppelin/upgrades-core": "^1.24.0",
     "@prb/math": "^4.0.0",
-    "@sphinx/contracts": "^0.9.0",
-    "@sphinx/core": "^0.12.0",
+    "@sphinx-labs/contracts": "^0.9.0",
+    "@sphinx-labs/core": "^0.12.0",
     "@swc/core": "^1.3.62",
     "core-js": "^3.31.1",
     "dotenv": "^16.0.3",

--- a/packages/plugins/remappings.txt
+++ b/packages/plugins/remappings.txt
@@ -1,5 +1,5 @@
 hardhat=../../node_modules/hardhat/
-@sphinx/contracts/=../contracts
+@sphinx-labs/contracts/=../contracts
 @openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
 forge-std/=node_modules/forge-std/src/
@@ -9,5 +9,5 @@ solidity-stringutils=node_modules/solidity-stringutils/src/
 @eth-optimism/contracts/=node_modules/@eth-optimism/contracts/
 solmate/src/=node_modules/solmate/src/
 @prb/math/=node_modules/prb/math/src/
-@sphinx/plugins=./foundry-contracts/
+@sphinx-labs/plugins=./foundry-contracts/
 @layerzerolabs/solidity-examples/contracts/=node_modules/@layerzerolabs/solidity-examples/contracts/

--- a/packages/plugins/script/display-bundle-info.ts
+++ b/packages/plugins/script/display-bundle-info.ts
@@ -6,7 +6,7 @@ import {
   getParsedConfig,
   getProjectBundleInfo,
   readUserConfig,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { utils } from 'ethers'
 
 import { makeGetConfigArtifacts } from '../src/hardhat/artifacts'

--- a/packages/plugins/script/write-constants.ts
+++ b/packages/plugins/script/write-constants.ts
@@ -6,7 +6,7 @@ import {
   OZ_UUPS_OWNABLE_PROXY_TYPE_HASH,
   OZ_UUPS_ACCESS_CONTROL_PROXY_TYPE_HASH,
   EXTERNAL_TRANSPARENT_PROXY_TYPE_HASH,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import {
   CURRENT_SPHINX_MANAGER_VERSION,
   getSphinxRegistryAddress,
@@ -19,7 +19,7 @@ import {
   getSphinxConstants,
   AUTH_FACTORY_ADDRESS,
   AUTH_IMPL_V1_ADDRESS,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { remove0x } from '@eth-optimism/core-utils'
 import { ethers } from 'ethers'
 

--- a/packages/plugins/sphinx/Metatx.config.ts
+++ b/packages/plugins/sphinx/Metatx.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 const projectName = 'Metatxs'
 

--- a/packages/plugins/sphinx/Storage.config.ts
+++ b/packages/plugins/sphinx/Storage.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 import {
   variables,

--- a/packages/plugins/sphinx/Website.config.ts
+++ b/packages/plugins/sphinx/Website.config.ts
@@ -1,4 +1,4 @@
-import { UserConfigWithOptions } from '@sphinx/core'
+import { UserConfigWithOptions } from '@sphinx-labs/core'
 
 const ownerAddress = '0x9fd58Bf0F2E6125Ffb0CBFa9AE91893Dbc1D5c51'
 

--- a/packages/plugins/sphinx/manager-upgrade.config.ts
+++ b/packages/plugins/sphinx/manager-upgrade.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 // This config tests an upgrade of the SphinxManager's version. We use a config
 // with a different owner because otherwise the SphinxManager's version will

--- a/packages/plugins/sphinx/validation/ConstructorArgValidation.config.ts
+++ b/packages/plugins/sphinx/validation/ConstructorArgValidation.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 import {
   invalidConstructorArgsPartOne,

--- a/packages/plugins/sphinx/validation/Reverter.config.ts
+++ b/packages/plugins/sphinx/validation/Reverter.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 const config: UserConfig = {
   projectName: 'Reverter',

--- a/packages/plugins/sphinx/validation/Validation.config.ts
+++ b/packages/plugins/sphinx/validation/Validation.config.ts
@@ -1,4 +1,4 @@
-import { UserConfig } from '@sphinx/core'
+import { UserConfig } from '@sphinx-labs/core'
 
 const config: UserConfig = {
   projectName: 'Validation',

--- a/packages/plugins/src/cli/index.ts
+++ b/packages/plugins/src/cli/index.ts
@@ -7,9 +7,9 @@ import * as dotenv from 'dotenv'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import ora from 'ora'
-import { execAsync } from '@sphinx/core/dist/utils'
+import { execAsync } from '@sphinx-labs/core/dist/utils'
 import { satisfies } from 'semver'
-import { getSphinxManagerAddress } from '@sphinx/core/dist/addresses'
+import { getSphinxManagerAddress } from '@sphinx-labs/core/dist/addresses'
 import { Wallet, providers } from 'ethers/lib/ethers'
 import {
   getDiff,
@@ -20,7 +20,7 @@ import {
   ensureSphinxInitialized,
   proposeAbstractTask,
   UserConfigWithOptions,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import 'core-js/features/array/at'
 
 import { writeSampleProjectFiles } from '../sample-project'
@@ -44,7 +44,7 @@ const confirmOption = 'confirm'
 const broadcastOption = 'broadcast'
 
 const rootFfiPath =
-  process.env.DEV_FILE_PATH ?? './node_modules/@sphinx/plugins/'
+  process.env.DEV_FILE_PATH ?? './node_modules/@sphinx-labs/plugins/'
 
 yargs(hideBin(process.argv))
   .scriptName('sphinx')

--- a/packages/plugins/src/cre.ts
+++ b/packages/plugins/src/cre.ts
@@ -1,6 +1,6 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { SphinxRuntimeEnvironment } from '@sphinx/core/dist/types'
-import { Integration } from '@sphinx/core/dist/constants'
+import { SphinxRuntimeEnvironment } from '@sphinx-labs/core/dist/types'
+import { Integration } from '@sphinx-labs/core/dist/constants'
 
 import { importOpenZeppelinStorageLayout } from './hardhat/artifacts'
 

--- a/packages/plugins/src/foundry/artifacts.ts
+++ b/packages/plugins/src/foundry/artifacts.ts
@@ -1,17 +1,20 @@
 import { readFileSync } from 'fs'
 import { join, sep } from 'path'
 
-import { writeDeploymentArtifacts } from '@sphinx/core/dist/actions/artifacts'
-import { DeploymentState } from '@sphinx/core/dist/actions/types'
-import { getSphinxManagerAddress } from '@sphinx/core/dist/addresses'
-import { CompilerConfig, ConfigArtifacts } from '@sphinx/core/dist/config/types'
+import { writeDeploymentArtifacts } from '@sphinx-labs/core/dist/actions/artifacts'
+import { DeploymentState } from '@sphinx-labs/core/dist/actions/types'
+import { getSphinxManagerAddress } from '@sphinx-labs/core/dist/addresses'
+import {
+  CompilerConfig,
+  ConfigArtifacts,
+} from '@sphinx-labs/core/dist/config/types'
 import {
   getDeploymentEvents,
   getNetworkDirName,
   getNetworkType,
   getSphinxManagerReadOnly,
   resolveNetwork,
-} from '@sphinx/core/dist/utils'
+} from '@sphinx-labs/core/dist/utils'
 import { providers } from 'ethers/lib/ethers'
 import { Ora } from 'ora'
 

--- a/packages/plugins/src/foundry/display-user-config.ts
+++ b/packages/plugins/src/foundry/display-user-config.ts
@@ -1,6 +1,6 @@
 import { argv } from 'process'
 
-import { readUserSphinxConfig } from '@sphinx/core/dist/config/config'
+import { readUserSphinxConfig } from '@sphinx-labs/core/dist/config/config'
 
 const configPath = argv[2]
 if (typeof configPath !== 'string') {

--- a/packages/plugins/src/foundry/get-bundle-info.ts
+++ b/packages/plugins/src/foundry/get-bundle-info.ts
@@ -4,9 +4,9 @@ import fs from 'fs'
 import {
   getUnvalidatedContractConfigs,
   postParsingValidation,
-} from '@sphinx/core/dist/config/parse'
-import { FailureAction } from '@sphinx/core/dist/types'
-import { getProjectBundleInfo } from '@sphinx/core/dist/tasks'
+} from '@sphinx-labs/core/dist/config/parse'
+import { FailureAction } from '@sphinx-labs/core/dist/types'
+import { getProjectBundleInfo } from '@sphinx-labs/core/dist/tasks'
 import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
 import { remove0x } from '@eth-optimism/core-utils/dist/common/hex-strings'
 import {
@@ -14,7 +14,7 @@ import {
   getSphinxManagerAddress,
   getDeployContractCosts,
   writeCompilerConfig,
-} from '@sphinx/core/dist'
+} from '@sphinx-labs/core/dist'
 
 import { createSphinxRuntime } from '../cre'
 import { getFoundryConfigOptions } from './options'
@@ -55,7 +55,7 @@ const ownerAddress = args[3]
     }
 
     const rootImportPath =
-      process.env.DEV_FILE_PATH ?? './node_modules/@sphinx/plugins/'
+      process.env.DEV_FILE_PATH ?? './node_modules/@sphinx-labs/plugins/'
     const utilsArtifactFolder = `${rootImportPath}out/artifacts`
 
     const SphinxUtilsABI =

--- a/packages/plugins/src/foundry/get-configs.ts
+++ b/packages/plugins/src/foundry/get-configs.ts
@@ -4,7 +4,7 @@ import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
 import {
   getFoundryConfig,
   readUserSphinxConfig,
-} from '@sphinx/core/dist/config/config'
+} from '@sphinx-labs/core/dist/config/config'
 
 import { getEncodedFailure, validationStderrWrite } from './logs'
 
@@ -24,7 +24,7 @@ const ownerAddress = args[1]
     const minimalConfig = getFoundryConfig(userConfig, ownerAddress)
 
     const rootImportPath =
-      process.env.DEV_FILE_PATH ?? './node_modules/@sphinx/plugins/'
+      process.env.DEV_FILE_PATH ?? './node_modules/@sphinx-labs/plugins/'
     const utilsArtifactFolder = `${rootImportPath}out/artifacts`
 
     const SphinxUtilsABI =

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -7,7 +7,7 @@ import {
   proposeAbstractTask,
   readUserConfigWithOptions,
   ensureSphinxInitialized,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { ethers } from 'ethers'
 import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
 

--- a/packages/plugins/src/foundry/structs.ts
+++ b/packages/plugins/src/foundry/structs.ts
@@ -1,4 +1,4 @@
-import { MinimalConfigCache } from '@sphinx/core/dist/config/types'
+import { MinimalConfigCache } from '@sphinx-labs/core/dist/config/types'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 
 export const decodeCachedConfig = (

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -5,18 +5,18 @@ import { promisify } from 'util'
 import {
   BuildInfo,
   ContractArtifact,
-} from '@sphinx/core/dist/languages/solidity/types'
+} from '@sphinx-labs/core/dist/languages/solidity/types'
 import {
   parseFoundryArtifact,
   validateBuildInfo,
   execAsync,
-} from '@sphinx/core/dist/utils'
+} from '@sphinx-labs/core/dist/utils'
 import {
   ConfigArtifacts,
   GetConfigArtifacts,
   GetProviderForChainId,
   UserContractConfigs,
-} from '@sphinx/core/dist/config/types'
+} from '@sphinx-labs/core/dist/config/types'
 import { parse } from 'semver'
 import { providers } from 'ethers/lib/ethers'
 

--- a/packages/plugins/src/hardhat/artifacts.ts
+++ b/packages/plugins/src/hardhat/artifacts.ts
@@ -15,7 +15,7 @@ import {
   validateBuildInfo,
   GetProviderForChainId,
   ConfigArtifacts,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import {
   Manifest,
   getStorageLayoutForAddress,

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -14,7 +14,7 @@ import {
   getNetworkDirName,
   resolveNetwork,
   getNetworkType,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 export const fetchFilesRecursively = (dir): string[] => {

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -23,7 +23,7 @@ import {
   NetworkType,
   resolveNetwork,
   getNetworkDirName,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import ora from 'ora'
 import * as dotenv from 'dotenv'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'

--- a/packages/plugins/src/hardhat/type-extensions.ts
+++ b/packages/plugins/src/hardhat/type-extensions.ts
@@ -4,7 +4,7 @@ import { extendConfig, extendEnvironment } from 'hardhat/config'
 import { ethers } from 'ethers'
 import { lazyObject } from 'hardhat/plugins'
 import { HardhatConfig, HardhatRuntimeEnvironment } from 'hardhat/types'
-import { UserSalt } from '@sphinx/core'
+import { UserSalt } from '@sphinx-labs/core'
 
 import { getContract, resetSphinxDeployments } from './deployments'
 

--- a/packages/plugins/src/sample-project/index.ts
+++ b/packages/plugins/src/sample-project/index.ts
@@ -5,7 +5,7 @@ export * from './sample-config-files'
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { Integration } from '@sphinx/core'
+import { Integration } from '@sphinx-labs/core'
 
 import {
   forgeConfig,

--- a/packages/plugins/src/sample-project/sample-config-files.ts
+++ b/packages/plugins/src/sample-project/sample-config-files.ts
@@ -1,4 +1,4 @@
-export const sampleSphinxFileTypeScript = `import { UserConfig } from '@sphinx/core'
+export const sampleSphinxFileTypeScript = `import { UserConfig } from '@sphinx-labs/core'
 
 const config: UserConfig = {
   projectName: 'MyProject',
@@ -55,10 +55,10 @@ build_info = true
 extra_output = ['storageLayout', 'evm.gasEstimates']
 fs_permissions = [{ access = "read", path = "./"}]
 remappings=[
-  'forge-std/=node_modules/@sphinx/plugins/node_modules/forge-std/src/',
-  'ds-test/=node_modules/@sphinx/plugins/node_modules/ds-test/src/',
-  '@sphinx/plugins=node_modules/@sphinx/plugins/contracts/foundry',
-  '@sphinx/contracts=node_modules/@sphinx/contracts/'
+  'forge-std/=node_modules/@sphinx-labs/plugins/node_modules/forge-std/src/',
+  'ds-test/=node_modules/@sphinx-labs/plugins/node_modules/ds-test/src/',
+  '@sphinx-labs/plugins=node_modules/@sphinx-labs/plugins/contracts/foundry',
+  '@sphinx-labs/contracts=node_modules/@sphinx-labs/contracts/'
 ]
 
 [rpc_endpoints]

--- a/packages/plugins/src/sample-project/sample-contract.ts
+++ b/packages/plugins/src/sample-project/sample-contract.ts
@@ -25,7 +25,7 @@ export const getSampleFoundryTestFile = (
   return `// SPDX-License-Identifier: MIT
 pragma solidity ^${solcVersion};
 
-import { Sphinx } from "@sphinx/plugins/Sphinx.sol";
+import { Sphinx } from "@sphinx-labs/plugins/Sphinx.sol";
 import { Test } from "forge-std/Test.sol";
 import { HelloSphinx } from "../contracts/HelloSphinx.sol";
 

--- a/packages/plugins/src/sample-project/sample-tests.ts
+++ b/packages/plugins/src/sample-project/sample-tests.ts
@@ -1,4 +1,4 @@
-export const sampleTestFileTypeScript = `import '@sphinx/plugins'
+export const sampleTestFileTypeScript = `import '@sphinx-labs/plugins'
 import { sphinx, ethers } from 'hardhat'
 import { expect } from 'chai'
 import { Signer, Contract } from 'ethers'
@@ -48,7 +48,7 @@ describe('HelloSphinx', () => {
 })
 `
 
-export const sampleTestFileJavaScript = `require('@sphinx/plugins')
+export const sampleTestFileJavaScript = `require('@sphinx-labs/plugins')
 const { sphinx, ethers } = require('hardhat')
 const { expect } = require('chai')
 const { Signer, Contract } = require('ethers')

--- a/packages/plugins/test/Create3.spec.ts
+++ b/packages/plugins/test/Create3.spec.ts
@@ -9,7 +9,7 @@ import {
   getParsedConfig,
   getSphinxManagerAddress,
   getTargetAddress,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 
 import * as plugins from '../dist'
 import { createSphinxRuntime } from '../src/cre'

--- a/packages/plugins/test/ManagerUpgrade.spec.ts
+++ b/packages/plugins/test/ManagerUpgrade.spec.ts
@@ -3,11 +3,11 @@ import '../dist' // Imports type extensions for hre.sphinx
 
 import hre, { sphinx } from 'hardhat'
 import { BigNumber, Contract, Signer } from 'ethers'
-import { getSphinxManagerAddress, getSphinxRegistry } from '@sphinx/core'
+import { getSphinxManagerAddress, getSphinxRegistry } from '@sphinx-labs/core'
 import {
   SphinxManagerProxyArtifact,
   OWNER_MULTISIG_ADDRESS,
-} from '@sphinx/contracts'
+} from '@sphinx-labs/contracts'
 import { expect } from 'chai'
 
 const ownerAddress = '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f'

--- a/packages/plugins/test/Metatx.spec.ts
+++ b/packages/plugins/test/Metatx.spec.ts
@@ -12,8 +12,8 @@
 //   getSphinxRegistry,
 //   ProposalRoute,
 //   readParsedConfig,
-// } from '@sphinx/core'
-// import { ForwarderArtifact } from '@sphinx/contracts'
+// } from '@sphinx-labs/core'
+// import { ForwarderArtifact } from '@sphinx-labs/contracts'
 // import { expect } from 'chai'
 // import ora from 'ora'
 

--- a/packages/plugins/test/MultiChain.spec.ts
+++ b/packages/plugins/test/MultiChain.spec.ts
@@ -20,8 +20,12 @@ import {
   proposeAbstractTask,
   findProposalRequestLeaf,
   fromProposalRequestLeafToRawAuthLeaf,
-} from '@sphinx/core'
-import { AuthFactoryABI, AuthABI, SphinxManagerABI } from '@sphinx/contracts'
+} from '@sphinx-labs/core'
+import {
+  AuthFactoryABI,
+  AuthABI,
+  SphinxManagerABI,
+} from '@sphinx-labs/contracts'
 import { expect } from 'chai'
 import { BigNumber, ethers } from 'ethers'
 

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -6,7 +6,7 @@ import {
   ensureSphinxInitialized,
   getParsedConfig,
   readUserConfig,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 import '@nomiclabs/hardhat-ethers'
 
 import { createSphinxRuntime } from '../src/cre'

--- a/packages/plugins/test/constants.ts
+++ b/packages/plugins/test/constants.ts
@@ -13,7 +13,7 @@ import {
   getAuthAddress,
   getAuthData,
   getSphinxManagerAddress,
-} from '@sphinx/core'
+} from '@sphinx-labs/core'
 
 import { createSphinxRuntime } from '../src/cre'
 

--- a/packages/plugins/test/foundry/Sphinx.t.sol
+++ b/packages/plugins/test/foundry/Sphinx.t.sol
@@ -8,15 +8,15 @@ import { SimpleStorage } from "../../contracts/test/SimpleStorage.sol";
 import { OtherImmutables, Storage, Types } from "../../contracts/test/ContainsStorage.sol";
 import { ComplexConstructorArgs } from "../../contracts/test/ComplexConstructorArgs.sol";
 import { Stateless } from "../../contracts/test/Stateless.sol";
-import { SphinxRegistry } from "@sphinx/contracts/contracts/SphinxRegistry.sol";
-import { SphinxManager } from "@sphinx/contracts/contracts/SphinxManager.sol";
-import { SphinxManagerProxy } from "@sphinx/contracts/contracts/SphinxManagerProxy.sol";
+import { SphinxRegistry } from "@sphinx-labs/contracts/contracts/SphinxRegistry.sol";
+import { SphinxManager } from "@sphinx-labs/contracts/contracts/SphinxManager.sol";
+import { SphinxManagerProxy } from "@sphinx-labs/contracts/contracts/SphinxManagerProxy.sol";
 import {
     ISphinxManager
-} from "@sphinx/contracts/contracts/interfaces/ISphinxManager.sol";
-import { IProxyAdapter } from "@sphinx/contracts/contracts/interfaces/IProxyAdapter.sol";
-import { IProxyUpdater } from "@sphinx/contracts/contracts/interfaces/IProxyUpdater.sol";
-import { ICreate3 } from "@sphinx/contracts/contracts/interfaces/ICreate3.sol";
+} from "@sphinx-labs/contracts/contracts/interfaces/ISphinxManager.sol";
+import { IProxyAdapter } from "@sphinx-labs/contracts/contracts/interfaces/IProxyAdapter.sol";
+import { IProxyUpdater } from "@sphinx-labs/contracts/contracts/interfaces/IProxyUpdater.sol";
+import { ICreate3 } from "@sphinx-labs/contracts/contracts/interfaces/ICreate3.sol";
 
 /* Sphinx Foundry Library Tests
  *

--- a/packages/plugins/test/helpers.ts
+++ b/packages/plugins/test/helpers.ts
@@ -19,8 +19,12 @@ import {
   UserConfigWithOptions,
   CanonicalConfig,
   GetCanonicalConfig,
-} from '@sphinx/core'
-import { AuthABI, PROPOSER_ROLE, SphinxManagerABI } from '@sphinx/contracts'
+} from '@sphinx-labs/core'
+import {
+  AuthABI,
+  PROPOSER_ROLE,
+  SphinxManagerABI,
+} from '@sphinx-labs/contracts'
 import { expect } from 'chai'
 import { BigNumber, ethers } from 'ethers'
 


### PR DESCRIPTION
## Purpose
Renames package scope to `sphinx-labs` because `sphinx` is not available on npm.