### PR TITLE
fix(core): Resolve bug sending transactions on polygon mainnet

### DIFF
--- a/.changeset/hip-queens-brush.md
+++ b/.changeset/hip-queens-brush.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Fix polygon mainnet gas price bug

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -409,6 +409,20 @@ export const getGasPriceOverrides = async (
     overridden.maxPriorityFeePerGas = maxPriorityFeePerGas
   }
 
+  // Overrides the maxPriorityFeePerGas for Polygon mainnet
+  // This handles an issue where ethers does not work as expected for polygon mainnet due to how
+  // they handle transaction pricing post EIP-1559. If/when we upgrade to Ethers v6, this issue
+  // will be resolved by Ethers internally.
+  if (
+    (await provider.getNetwork()).chainId === 137 &&
+    (await getNetworkType(provider as ethers.providers.JsonRpcProvider)) ===
+      NetworkType.LIVE_NETWORK
+  ) {
+    overridden.maxPriorityFeePerGas = (
+      await provider.getFeeData()
+    ).maxFeePerGas?.toString()
+  }
+
   return overridden
 }
 


### PR DESCRIPTION
## Purpose
Fixes an issue where the `getGasPriceOverrides` function returns a gas price that causes transactions to hang on polygon mainnet. This is due to an underlying bug in how Ethers interacts with Polygons implementation of EIP-1559. This issue has been natively resolved in Ethers v6, but migrating to the new Ethers version is non trivial so I've [implemented a simple workaround](https://github.com/ethers-io/ethers.js/issues/2828#issuecomment-1603383487). However, we should migrate to Ethers v6 when we have time for it as this workaround does not fully resolve the issue. This workaround simply makes it possible to send transactions on polygon using Ethers, but it's somewhat unreliable (I had to restart the core contract deployment process 3 times before it fully completed). 