### PR TITLE
Readme link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ More networks are on the way! Please feel free to reach out in our [Discord](htt
 
 ## Contributing
 
-Contributions to Sphinx are greatly appreciated! To get started, please read our [contributing guide](https://github.com/sphinx/sphinx/blob/develop/CONTRIBUTING.md). Then, check out the list of [Good First Issues](https://github.com/sphinx/sphinx/contribute). Let us know if you have any questions!
+Contributions to Sphinx are greatly appreciated! To get started, please read our [contributing guide](https://github.com/sphinx-labs/sphinx/blob/develop/CONTRIBUTING.md). Then, check out the list of [Good First Issues](https://github.com/sphinx-labs/sphinx/contribute). Let us know if you have any questions!
 
 ## Reach Out
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Request access [here](https://sphinx.dev).
 Sphinx can either be used as a standalone CLI tool for deployments on a single chain, or as a DevOps platform that extends the CLI tool with additional functionality, such as one-click multi-chain deployments and automatic Etherscan verification.
 
 ### Standalone CLI
+
 - Define deployments in a declarative config file instead of writing deployment scripts
 - Consistent addresses across networks via `CREATE3`
 - Deployment artifacts in the same format as [`hardhat-deploy`](https://github.com/wighawag/hardhat-deploy)
 - Available as a Foundry and Hardhat plugin
 
 ### DevOps Platform
+
 - Approve multi-chain deployments with a single meta transaction
 - Maintain a balance of USDC on a single chain to fund deployments
 - Automatic Etherscan verification
@@ -22,7 +24,8 @@ Sphinx can either be used as a standalone CLI tool for deployments on a single c
 
 ## Documentation
 
-### Getting Started:
+### Getting Started
+
 - Foundry:
   - [Quickstart](https://github.com/sphinx-labs/sphinx/blob/develop/docs/cli-foundry-quickstart.md)
   - [Integrate Sphinx into an Existing Project](https://github.com/sphinx-labs/sphinx/blob/develop/docs/cli-foundry-existing-project.md)
@@ -32,7 +35,8 @@ Sphinx can either be used as a standalone CLI tool for deployments on a single c
   - [Getting Started (JavaScript)](https://github.com/sphinx-labs/sphinx/blob/develop/docs/cli-hardhat-js-getting-started.md)
   - [Getting Started with the DevOps Platform](https://github.com/sphinx-labs/sphinx/blob/develop/docs/ops-hardhat-getting-started.md)
 
-### References:
+### References
+
 - [Sphinx Config File](https://github.com/sphinx-labs/sphinx/blob/develop/docs/config-file.md): Where you define smart contract deployments for a project.
 - [Constructor Arguments](https://github.com/sphinx-labs/sphinx/blob/develop/docs/constructor-args.md): Shows how every constructor argument type can be defined in a Sphinx config file.
 - [The `SphinxManager` Contract](https://github.com/sphinx-labs/sphinx/blob/develop/docs/sphinx-manager.md): The contract that deploys your project.
@@ -40,28 +44,29 @@ Sphinx can either be used as a standalone CLI tool for deployments on a single c
 
 ## Supported Networks
 
-* Ethereum
-* Optimism
-* Arbitrum
-* Polygon
-* Polygon zkEVM
-* BNB Smart Chain (aka BSC)
-* Gnosis Chain
-* Avalanche C-Chain
-* Linea
-* Fantom
+- Ethereum
+- Optimism
+- Arbitrum
+- Polygon
+- Polygon zkEVM
+- BNB Smart Chain (aka BSC)
+- Gnosis Chain
+- Avalanche C-Chain
+- Linea
+- Fantom
 
 Test networks:
-* Ethereum Goerli
-* Optimism Goerli
-* Arbitrum Goerli
-* Polygon Mumbai
-* Polygon zkEVM Testnet
-* BNB Smart Chain Testnet
-* Gnosis Chiado
-* Avalanche Fuji
-* Linea Goerli
-* Fantom Testnet
+
+- Ethereum Goerli
+- Optimism Goerli
+- Arbitrum Goerli
+- Polygon Mumbai
+- Polygon zkEVM Testnet
+- BNB Smart Chain Testnet
+- Gnosis Chiado
+- Avalanche Fuji
+- Linea Goerli
+- Fantom Testnet
 
 More networks are on the way! Please feel free to reach out in our [Discord](https://discord.gg/7Gc3DK33Np) if there are networks you'd like us to add.
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The URLs for "contributing guide" and "good first issues" are broken and return 404. This PR addresses this and other inconsequential markdown linting warnings such as using "-" instead of "*" for unordered lists.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please open an issue for it first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Type of change
<!--- Please delete options that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Contract Breaking Change (fix or feature that would cause the system to no longer work with contracts currently deployed on live networks)
- [x] Documentation update

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I believe like me, every other person would look at the README on first contact with the repo. Therefore, the error is obvious if they were to try reading through the `CONTRIBUTING.md` file through the README.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Please describe any automated tests you've added to test your changes. -->

## Example Sphinx Config (if appropriate):
