### PR TITLE
fix(core): fix proposal failure when nothing has changed

### DIFF
--- a/.changeset/slimy-buttons-love.md
+++ b/.changeset/slimy-buttons-love.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Allow proposal to succeed without doing anything

--- a/docs/ci-hardhat-proposals.md
+++ b/docs/ci-hardhat-proposals.md
@@ -1,4 +1,4 @@
-# Propose Deployments from your CI Process (Foundry)
+# Propose Deployments from your CI Process (Hardhat)
 
 We recommend that you propose from your CI process instead of using the command line. This ensures that your deployments are reproducible, and that they don't depend on a single developer's machine, which can be a source of bugs.
 
@@ -8,35 +8,72 @@ If you're using Sphinx's Foundry plugin instead of Foundry, check out the [Found
 
 ## Table of Contents
 
-TODO
+1. [Prerequisites](#1-prerequisites)
+2. [Create a new branch](#2-create-a-new-branch-in-your-repo)
+3. [Create a Github Actions folder](#3-create-a-github-actions-folder)
+4. [Create new workflow files](#4-create-new-workflow-files-sphinxdeployyml-and-sphinxdry-runyml)
+5. [Create the dry run workflow](#5-create-the-dry-run-workflow)
+6. [Create the propose workflow](#6-create-the-propose-workflow)
+7. [Test your integration](#7-test-your-integration)
+8. [Production Deployments](#8-production-deployments)
 
-## Prerequisites
+## 1. Prerequisites
 
 Make sure that you've already completed the [Getting Started with the DevOps Platform](https://github.com/sphinx-labs/sphinx/blob/develop/docs/ops-hardhat-getting-started.md) guide for the project you're going to use in this guide.
 
 Also, make sure that your `hardhat.config.ts` file has a `networks` section that contains an RPC endpoint for each network you want to support in your project.
 
-## Create a new branch in your repo
+## 2. Create a new branch in your repo
 
-`git checkout -B sphinx/integrate-ci`
+```
+git checkout -B sphinx/integrate-ci
+```
 
-## Create a Github Actions folder
+## 3. Create a Github Actions folder
 
 If you already have a `.github/` folder, you can skip this step.
 
 Run the following command in the root directory of your project:
 
-`mkdir -p .github/workflows`
+```
+mkdir -p .github/workflows
+```
 
-## Create a new workflow `deploy.yml`
+## 4. Create new workflow files `sphinx.deploy.yml` and `sphinx.dry-run.yml`
 
-`touch .github/workflows/deploy.yml`
+```
+touch .github/workflows/sphinx.dry-run.yml
+touch .github/workflows/sphinx.deploy.yml
+```
 
-## Create the action template
+## 5. Create the dry run workflow
+We'll first create a workflow that runs the `sphinx-propose` command with the `--dry-run` flag whenever a PR is opened and updated. Proposing with the dry run flag just checks that the proposal process will complete successfuly. So this check helps prevent you from accidentally merging a change where the deployment might fail during the proposal step.
 
-We'll create an action template that runs the `propose` command on every push to the `main` branch. We'll also use the `--dry-run` flag to check that a proposal will complete successfully whenever a PR is opened and updated.
+Copy and paste the following into your `sphinx.dry-run.yml` file:
 
-Copy and paste the following into your `deploy.yml` file:
+```
+name: Sphinx Dry Run
+env:
+    PROPOSER_PRIVATE_KEY: ${{ secrets.PROPOSER_PRIVATE_KEY }}
+    SPHINX_API_KEY: ${{ secrets.SPHINX_API_KEY }}
+    # Put any node provider API keys or urls here. For example:
+    # ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+
+# Performs a dryrun proposal when a PR is opened and updated to confirm the
+# proposal will complete successfully after a PR is merged
+on: pull_request
+
+jobs:
+  sphinx-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn install
+      - run: npx hardhat sphinx-propose --config-path ./sphinx/HelloSphinx.config.ts --dry-run --testnets
+```
+
+## 6. Create the propose workflow
+Now we'll create a workflow that runs the `sphinx-propose` command with the `--confirm` flag. The confirm flag overrides the manual confirmation required by the proposal command allowing the proposal command to complete automatically.
 
 ```
 name: Sphinx Propose
@@ -45,17 +82,6 @@ env:
     SPHINX_API_KEY: ${{ secrets.SPHINX_API_KEY }}
     # Put any node provider API keys or urls here. For example:
     # ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-
-# Performs a dryrun proposal when a PR is opened and updated to confirm the
-$ proposal will complete successfully after a PR is merged
-on: pull_request
-jobs:
-  sphinx-dry-run:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: yarn install
-      - run: npx hardhat sphinx-propose --config-path path/to/config --dry-run
 
 # Triggers a deployment when a change is merged to main
 on:
@@ -68,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install
-      - run: npx hardhat sphinx-propose --config-path path/to/config --confirm
+      - run: npx hardhat sphinx-propose --config ./sphinx/HelloSphinx.config.ts --confirm --testnets
 ```
 
 Here is a checklist of things to do before moving on:
@@ -79,6 +105,11 @@ Here is a checklist of things to do before moving on:
 - [ ] If your repository doesn't use `yarn install`, update the `yarn install` step under `jobs`.
 - [ ] Add the path to your Sphinx config in the `npx sphinx propose` command under `jobs`.
 
-## Test your integration
+## 7. Test your integration
 
-Push your branch to Github, open a PR, and merge it after the dryrun check completes. You can then go to https://www.sphinx.dev and you'll find your new deployment ready to be funded and approved.
+Push your branch to Github, open a PR, and merge it after the dryrun check completes. You can then go to https://www.sphinx.dev and you'll find your new deployment there.
+
+## 8. Production Deployments
+In this example we've configured the CI deployment process to deploy against test networks when merging to main. If you want to go straight to production, you can do so by switching out the `--testnets` flag for the `--mainnets` production.
+
+However, in practice you may want something different depending on your workflow. For a more robust setup we recommend using a `develop` branch and triggering testnet deployments when merging to that branch. Then you should setup a separate workflow to trigger production deployments when merging to main.

--- a/docs/ops-foundry-getting-started.md
+++ b/docs/ops-foundry-getting-started.md
@@ -35,7 +35,7 @@ Deployments are a three-step process with the DevOps platform.
 
 ## 3. Get testnet ETH on OP Goerli
 
-You'll need a small amount of testnet ETH on Optimism Goerli, which you can get at [their faucet](https://app.optimism.io/faucet). Later, you'll use this ETH to deploy a `SphinxBalance` contract, which is where you'll keep the USDC that pays for your multi-chain deployments. This contract only exists on Optimism Goerli (and Optimism Mainnet for production deployments), so it's a one-time cost.
+You'll need a small amount of testnet ETH on Optimism Goerli, which you can get at [their faucet](https://app.optimism.io/faucet). Later, you'll use this ETH to deploy a `SphinxBalance` contract. We require that you pay for the cost of your deployments by depositing USDC into this contract during execution. You'll need do go through this process on both test and production networks. On testnets we will provide you with testnet USDC to use. This contract only exists on Optimism Goerli (and Optimism Mainnet for production deployments), so deploying it is a one-time cost.
 
 ## 4. Get your credentials
 

--- a/docs/ops-hardhat-getting-started.md
+++ b/docs/ops-hardhat-getting-started.md
@@ -32,7 +32,7 @@ Deployments are a three-step process with the DevOps platform.
 
 ## 3. Get testnet ETH on OP Goerli
 
-You'll need a small amount of testnet ETH on Optimism Goerli, which you can get at [their faucet](https://app.optimism.io/faucet). Later, you'll use this ETH to deploy a `SphinxBalance` contract, which is where you'll keep the USDC that pays for your multi-chain deployments. This contract only exists on Optimism Goerli (and Optimism Mainnet for production deployments), so it's a one-time cost.
+You'll need a small amount of testnet ETH on Optimism Goerli, which you can get at [their faucet](https://app.optimism.io/faucet). Later, you'll use this ETH to deploy a `SphinxBalance` contract. We require that you pay for the cost of your deployments by depositing USDC into this contract during execution. You'll need do go through this process on both test and production networks. On testnets we will provide you with testnet USDC to use. This contract only exists on Optimism Goerli (and Optimism Mainnet for production deployments), so deploying it is a one-time cost.
 
 ## 4. Get your credentials
 

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -101,7 +101,7 @@ export const proposeAbstractTask = async (
   spinner: ora.Ora = ora({ isSilent: true }),
   failureAction: FailureAction = FailureAction.EXIT,
   getCanonicalConfig: GetCanonicalConfig = fetchCanonicalConfig
-): Promise<ProposalRequest> => {
+): Promise<ProposalRequest | undefined> => {
   const apiKey = process.env.SPHINX_API_KEY
   if (!apiKey) {
     throw new Error(`Must provide a 'SPHINX_API_KEY' environment variable.`)
@@ -228,6 +228,13 @@ export const proposeAbstractTask = async (
     // Confirm deployment with the user before proceeding.
     await userConfirmation(getDiffString(diff))
     spinner.start(`Proposal in progress...`)
+  }
+
+  if (leafs.length === 0) {
+    spinner.succeed(
+      `Proposal completed, nothing has changed so no new deployment was created.`
+    )
+    return
   }
 
   const chainIdToNumLeafs: { [chainId: number]: number } = {}


### PR DESCRIPTION
## Purpose
Fixes an issue where the proposal task throws an error if you attempt to propose when nothing has changed since the last deployment. This is an issue because if we throw an error here then it causes problems when using us in CI. The correct behavior is to simply do nothing and log that nothing is happening. This allows the CI check to succeed in this case.