### PR TITLE
fix(core): Combine previous canonical config with new config

### DIFF
--- a/.changeset/rare-sloths-invent.md
+++ b/.changeset/rare-sloths-invent.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Combine previous canonical config with new config

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -358,9 +358,15 @@ export const proposeAbstractTask = async (
   const newCanonicalConfig: CanonicalConfig = {
     manager: prevConfig.manager,
     options: parsedConfig.options,
-    contracts: parsedConfig.contracts,
+    contracts: {
+      ...prevConfig.contracts,
+      ...parsedConfig.contracts,
+    },
     projectName: parsedConfig.projectName,
-    chainStates: newChainStates,
+    chainStates: {
+      ...prevConfig.chainStates,
+      ...newChainStates,
+    },
   }
 
   // We calculate the auth address based on the current owners since this is used to store the


### PR DESCRIPTION
## Purpose
Fixes an issue where removing some data from your config file can result in our DB containing a slightly out-of-date canonical config which can result in bugged deployments. 

For example prior to this PR, if I deployed with this config: 
```
const config: UserConfigWithOptions = {
  projectName: 'Foundry Deployment',
  options: {
    orgId: <ORG_ID>,
    owners: [<OWNER>],
    ownerThreshold: 1,
    testnets: ['arbitrum-goerli'],
    mainnets: [],
    proposers: [<PROPOSER>],
  },
  contracts: ...
}
```

And then I deployed with this config: 
```
const config: UserConfigWithOptions = {
  projectName: 'Foundry Deployment',
  options: {
    orgId: <ORG_ID>,
    owners: [<OWNER>],
    ownerThreshold: 1,
    testnets: ['optimism-goerli'],
    mainnets: [],
    proposers: [<PROPOSER>],
  },
  contracts: ...
}
```

The canonical config in the DB would contain chain status' for only the chain status for optimism goerli. So then, if I deployed with this config the deployment would bug out because our system would think the user never deployed on optimism goerli. 
```
const config: UserConfigWithOptions = {
  projectName: 'Foundry Deployment',
  options: {
    orgId: <ORG_ID>,
    owners: [<OWNER>],
    ownerThreshold: 1,
    testnets: ['optimism-goerli', 'arbitrum-goerli'],
    mainnets: [],
    proposers: [<PROPOSER>],
  },
  contracts: ...
}
```

This PR fixes this by making sure the previous canonical config is combined with the new canonical config. Even though we don't recommend doing something like this, we need to handle it unless we actually implement logic for preventing the user from removing stuff from their config which I don't think we should. In the future, if we add more stuff to the canonical config, or change it we'll need to make sure we continue to handle doing the combination. 
