### PR TITLE
fix(mt): Merkle tree generation invariant five test incomplete

### DIFF
--- a/packages/contracts/test/mocha/merkle-tree.spec.ts
+++ b/packages/contracts/test/mocha/merkle-tree.spec.ts
@@ -102,7 +102,8 @@ const assertInvariantFive = (tree: SphinxMerkleTree) => {
     const leaf = leafWithProof.leaf
 
     if (leaf.leafType === SphinxLeafType.EXECUTE) {
-      // Expect that there was no CANCEL leaf for
+      // Expect that there was no CANCEL leaf for the chain
+      expect(seenCancelChainIds.includes(leaf.chainId)).to.be.false
     }
   }
 }


### PR DESCRIPTION
## Purpose
- Fixes an [issue where the check for Merkle tree invariant 5 in `merkle-tree.spec.ts` was incomplete](https://discord.com/channels/883432404780466176/1176261963106492526/1177463360426618962).