### PR TITLE
fix(pg): stop requiring the user to override the `run()` function in their script

### DIFF
--- a/.changeset/small-seas-arrive.md
+++ b/.changeset/small-seas-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Stop requiring the user to override the `run()` function in their script.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tsconfig.tsbuildinfo
 
 # vim
 *.sw*
+
+# env
+.env

--- a/docs/cli-existing-project.md
+++ b/docs/cli-existing-project.md
@@ -124,7 +124,7 @@ The entry point of your deployment script must be a `run()` function; it cannot 
 Then, add a `sphinx` modifier to your `run` function:
 
 ```sol
-function run() sphinx public override {
+function run() sphinx public {
     ...
 }
 ```

--- a/docs/writing-scripts.md
+++ b/docs/writing-scripts.md
@@ -25,7 +25,7 @@ address safe = sphinxSafe();
 The entry point for your deployment must always be a `run()` function that has a `sphinx` modifier:
 
 ```sol
-function run() public sphinx override {
+function run() public sphinx {
     ...
 }
 ```

--- a/packages/plugins/contracts/test/script/Cases.s.sol
+++ b/packages/plugins/contracts/test/script/Cases.s.sol
@@ -22,7 +22,7 @@ contract Simple is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         // Deploy with Create2
         Fallback fallbackCreate2 = new Fallback{ salt: 0 }(-1);
         // Perform low level call to fallback function

--- a/packages/plugins/contracts/test/script/Empty.s.sol
+++ b/packages/plugins/contracts/test/script/Empty.s.sol
@@ -16,5 +16,5 @@ contract Empty is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {}
+    function run() public sphinx {}
 }

--- a/packages/plugins/contracts/test/script/Large.s.sol
+++ b/packages/plugins/contracts/test/script/Large.s.sol
@@ -16,7 +16,7 @@ contract Simple is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         new MyLargeContract{ salt: bytes32(uint(0)) }();
         new MyLargeContract{ salt: bytes32(uint(1)) }();
         new MyLargeContract{ salt: bytes32(uint(2)) }();

--- a/packages/plugins/contracts/test/script/PartiallyEmpty.s.sol
+++ b/packages/plugins/contracts/test/script/PartiallyEmpty.s.sol
@@ -16,7 +16,7 @@ contract PartiallyEmpty is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         // Deploy a contract on Ethereum and don't deploy anything on Optimism.
         if (block.chainid == 1) {
             new MyContract2{ salt: 0 }();

--- a/packages/plugins/contracts/test/script/RevertDuringSimulation.s.sol
+++ b/packages/plugins/contracts/test/script/RevertDuringSimulation.s.sol
@@ -17,7 +17,7 @@ contract RevertDuringSimulation_Script is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         RevertDuringSimulation reverter = new RevertDuringSimulation{ salt: 0 }(sphinxModule());
         reverter.revertDuringSimulation();
     }

--- a/packages/plugins/contracts/test/script/Simple.s.sol
+++ b/packages/plugins/contracts/test/script/Simple.s.sol
@@ -17,7 +17,7 @@ contract Simple1 is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         MyContract2 myContract;
         Network network = getSphinxNetwork(block.chainid);
         if (network == Network.ethereum || network == Network.sepolia) {
@@ -39,7 +39,7 @@ contract Simple2 is Script, Sphinx {
         sphinxConfig.orgId = "test-org-id";
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         new MyContract2{ salt: bytes32(uint(2)) }();
     }
 }

--- a/packages/plugins/script/Sample.s.sol
+++ b/packages/plugins/script/Sample.s.sol
@@ -20,7 +20,7 @@ contract Sample is Sphinx {
         sphinxConfig.saltNonce = 0;
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         new MyContract1{ salt: bytes32(uint(1)) }(
             -1,
             2,

--- a/packages/plugins/src/sample-project/sample-contracts.ts
+++ b/packages/plugins/src/sample-project/sample-contracts.ts
@@ -54,7 +54,7 @@ contract HelloSphinxScript is Sphinx {
         ];
     }
 
-    function run() public override sphinx {
+    function run() public sphinx {
         helloSphinx = new HelloSphinx{ salt: bytes32(0) }("Hi", 2);
         helloSphinx.add(8);
     }


### PR DESCRIPTION
Before this PR, the user's `run` function needed to include the `override` keyword. After this PR, this keyword is no longer included.

We should make this change now because it's a breaking change that's necessary to allow the user to use function names other than `run()` in their script, which we plan to support in the future. It's a breaking change because the Solidity compiler will throw this error if the user attempts to override a function that doesn't exist: `Error (7792): Function has override specified but does not override anything.`