### PR TITLE
feat(core): Allow disabling gas price overrides

### DIFF
--- a/.changeset/slimy-toes-taste.md
+++ b/.changeset/slimy-toes-taste.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Allow disabling gas price overrides

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -149,6 +149,13 @@ export const getGasPriceOverrides = async (
   signer: ethers.Signer,
   overridden: ethers.TransactionRequest = {}
 ): Promise<ethers.TransactionRequest> => {
+  // Allows us to test cases where we execute deployments using wallets with normal amounts of funds on local networks.
+  // If we do not disable this function using the env variable, then the gas limit will be set extremely high which
+  // will cause transactions to fail for wallets with normal amounts of funds.
+  if (process.env.SPHINX_INTERNAL__DISABLE_GAS_PRICE_OVERRIDES) {
+    return overridden
+  }
+
   const [block, isLiveNetwork_, feeData, network] = await Promise.all([
     provider.getBlock('latest'),
     isLiveNetwork(provider),

--- a/packages/plugins/script/Sample.s.sol
+++ b/packages/plugins/script/Sample.s.sol
@@ -11,7 +11,7 @@ contract Sample is Sphinx {
     MyContract1 myContract;
 
     function setUp() public {
-        sphinxConfig.projectName = "test project";
+        sphinxConfig.projectName = "test_project";
         sphinxConfig.owners = [0x9fd58Bf0F2E6125Ffb0CBFa9AE91893Dbc1D5c51];
         sphinxConfig.threshold = 1;
         sphinxConfig.testnets = [Network.sepolia, Network.arbitrum_sepolia];


### PR DESCRIPTION
## Purpose
Adds an environment variable `SPHINX_INTERNAL__DISABLE_GAS_PRICE_OVERRIDES` which allows disabling the gas price overrides function.