### PR TITLE
perf(pg): compile as late as possible in CLI commands

### DIFF
--- a/.changeset/eleven-gorillas-destroy.md
+++ b/.changeset/eleven-gorillas-destroy.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Force compile as late as possible

--- a/packages/demo/test/Solc.spec.ts
+++ b/packages/demo/test/Solc.spec.ts
@@ -86,6 +86,8 @@ describe('Solidity Compiler', () => {
     // Generate output directory names. We use separate output directories for each compilation to
     // prevent race conditions.
     const outputDirs = versions.map((version) => `out-${version}`)
+    // Generate separate cache directory names to prevent race conditions.
+    const cacheDirs = versions.map((version) => `cache-${version}`)
 
     const buildPromises = versions.map((version, index) => {
       return spawnAsync(`forge`, [
@@ -99,6 +101,8 @@ describe('Solidity Compiler', () => {
         '--force',
         '--out',
         outputDirs[index],
+        '--cache-path',
+        cacheDirs[index],
       ]).then(({ stdout, stderr, code }) => {
         return { version, stdout, stderr, code }
       })
@@ -142,6 +146,8 @@ describe('Solidity Compiler', () => {
     // Generate output directory names. We use separate output directories for each compilation to
     // prevent race conditions.
     const outputDirs = versions.map((version) => `out-${version}`)
+    // Generate separate cache directory names to prevent race conditions.
+    const cacheDirs = versions.map((version) => `cache-${version}`)
 
     const buildPromises = versions.map((version, index) => {
       return spawnAsync(
@@ -154,6 +160,8 @@ describe('Solidity Compiler', () => {
           '--force',
           '--out',
           outputDirs[index],
+          '--cache-path',
+          cacheDirs[index],
         ],
         {
           FOUNDRY_PROFILE: 'no_optimizer',

--- a/packages/plugins/test/mocha/cli/deploy.spec.ts
+++ b/packages/plugins/test/mocha/cli/deploy.spec.ts
@@ -13,6 +13,7 @@ import {
   SphinxJsonRpcProvider,
   SphinxPreview,
   SphinxTransactionReceipt,
+  execAsync,
   getCreate3Address,
   makeDeploymentArtifacts,
 } from '@sphinx-labs/core'
@@ -169,6 +170,13 @@ describe('Deploy CLI command', () => {
     const projectName = 'Simple_Project_1'
 
     it('Executes deployment on local network', async () => {
+      // We run `forge clean` to ensure that a deployment can occur even if there are no existing
+      // contract artifacts. This is worthwhile to test because we read contract interfaces in the
+      // `deploy` function, which will fail if the function hasn't compiled the contracts yet. By
+      // running `forge clean` here, we're testing that this compilation occurs in the `deploy`
+      // function.
+      await execAsync(`forge clean`)
+
       const executionMode = ExecutionMode.LocalNetworkCLI
 
       expect(await provider.getCode(expectedMyContract2Address)).to.equal('0x')
@@ -188,8 +196,7 @@ describe('Deploy CLI command', () => {
           ]),
           verify: false,
           targetContract,
-          // Force recompile to ensure that a deployment can occur after a fresh compilation.
-          forceRecompile: true,
+          forceRecompile: false,
         })
 
       // Narrow the TypeScript types.

--- a/packages/plugins/test/mocha/cli/propose.spec.ts
+++ b/packages/plugins/test/mocha/cli/propose.spec.ts
@@ -6,6 +6,7 @@ import {
   ProposalRequest,
   SUPPORTED_NETWORKS,
   SphinxPreview,
+  execAsync,
   getNetworkNameForChainId,
   getSphinxWalletPrivateKey,
 } from '@sphinx-labs/core'
@@ -68,6 +69,13 @@ describe('Propose CLI command', () => {
   })
 
   it('Proposes with preview on a single testnet', async () => {
+    // We run `forge clean` to ensure that a proposal can occur even if there are no existing
+    // contract artifacts. This is worthwhile to test because we read contract interfaces in the
+    // `propose` function, which will fail if the function hasn't compiled the contracts yet. By
+    // running `forge clean` here, we're testing that this compilation occurs in the `propose`
+    // function.
+    await execAsync(`forge clean`)
+
     const scriptPath = 'contracts/test/script/Simple.s.sol'
     const isTestnet = true
     const targetContract = 'Simple1'
@@ -83,8 +91,7 @@ describe('Propose CLI command', () => {
         scriptPath,
         sphinxContext: context,
         targetContract,
-        // Force recompile to ensure that a proposal can occur after a fresh compilation process.
-        forceRecompile: true,
+        forceRecompile: false,
       })
 
     // This prevents a TypeScript type error.


### PR DESCRIPTION
Before this PR, the Deploy and Propose CLI commands force re-compiled the user's contracts at the beginning of the command. The problem is that it's common to spend a significant amount of time waiting for re-compilation to occur then run into an error thrown at some point later in the command. For example, this scenario can occur if an error is thrown in the user's script during the transaction collection phase. When this occurs, the user must then sit and wait for re-compilation to occur all over again. If this process repeats multiple times, it becomes quite frustrating to use our plugin.

This PR fixes the issue by force-recompiling as late as possible in these commands. Specifically, we force recompile before calling `getConfigArtifacts`. This PR also moves a bit of logic earlier in these commands so that re-compilation happens as late as possible.