### PR TITLE
docs: add `--confirm` flag to ci proposal template

### DIFF
--- a/docs/ci-proposals.md
+++ b/docs/ci-proposals.md
@@ -83,7 +83,7 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Dry Run
-        run: npx sphinx propose <path/to/your/script.s.sol> --dry-run --networks testnets
+        run: npx sphinx propose <path/to/your/script.s.sol> --dry-run --confirm --networks testnets
 ```
 
 Here is a list of things you may need to change in the template:


### PR DESCRIPTION
In our CI Proposal guide, the template dry run command was:
```
npx sphinx propose <path/to/your/script.s.sol> --dry-run --networks testnets
```

This command would hang indefinitely because the `--confirm` flag wasn't included.

We may want to rethink the UX of this since two flags may be somewhat redundant, but for now, I think this PR suffices.