### PR TITLE
fix(pg): use `CREATE2` salt in quickstart guide to prevent contract address collision

### DIFF
--- a/.changeset/modern-lies-design.md
+++ b/.changeset/modern-lies-design.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/demo': patch
+---
+
+Use `CREATE2` salt in quickstart guide to prevent contract address collision

--- a/packages/demo/test/init.spec.ts
+++ b/packages/demo/test/init.spec.ts
@@ -48,8 +48,10 @@ describe('Init CLI command', () => {
     expect(fs.existsSync(contractPath)).to.be.false
     expect(fs.existsSync(testPath)).to.be.false
 
+    const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
     await execAsync(
-      `npx sphinx init --org-id TEST_ORG_ID --sphinx-api-key TEST_SPHINX_KEY --alchemy-api-key TEST_ALCHEMY_KEY --owner 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
+      `npx sphinx init --org-id TEST_ORG_ID --sphinx-api-key TEST_SPHINX_KEY --alchemy-api-key TEST_ALCHEMY_KEY --owner ${ownerAddress}`
     )
 
     // Check that the files have been created
@@ -68,11 +70,15 @@ describe('Init CLI command', () => {
     const artifact =
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require(path.resolve('./out/HelloSphinx.sol/HelloSphinx.json'))
+
     // Get the sample contract's address.
     const coder = ethers.AbiCoder.defaultAbiCoder()
+    const create2Salt = ethers.keccak256(
+      coder.encode([`address[]`], [[ownerAddress]])
+    )
     const contractAddress = ethers.getCreate2Address(
       DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-      ethers.ZeroHash,
+      create2Salt,
       ethers.keccak256(
         ethers.concat([
           artifact.bytecode.object,

--- a/packages/plugins/src/sample-project/sample-contracts.ts
+++ b/packages/plugins/src/sample-project/sample-contracts.ts
@@ -55,7 +55,10 @@ contract HelloSphinxScript is Sphinx {
     }
 
     function run() public sphinx {
-        helloSphinx = new HelloSphinx{ salt: bytes32(0) }("Hi", 2);
+        // Set the \`CREATE2\` salt to be the hash of the owner(s). Prevents
+        // address collisions.
+        bytes32 salt = keccak256(abi.encode(sphinxConfig.owners));
+        helloSphinx = new HelloSphinx{ salt: salt }("Hi", 2);
         helloSphinx.add(8);
     }
 }


### PR DESCRIPTION
This PR fixes the quickstart guide, which broke because it attempted to deploy the sample contract to the same address for everybody.