### PR TITLE
maint(ci): Only run contract tests when branch is develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,18 @@ jobs:
           name: Lint
           command: yarn lint:check
           working_directory: packages/<<parameters.package_name>>
-      - run:
-          name: Test
-          command: yarn test:coverage
-          no_output_timeout: 20m
-          working_directory: packages/<<parameters.package_name>>
+      - when:
+          condition:
+            or:
+              - equal: [ "develop", << pipeline.git.branch >> ]
+              - not:
+                  equal: [ "contracts", <<parameters.package_name>> ]
+          steps:
+            - run:
+                name: Test
+                command: yarn test:coverage
+                no_output_timeout: 20m
+                working_directory: packages/<<parameters.package_name>>
 
   depcheck:
     docker:


### PR DESCRIPTION
## Purpose
Disables the contract tests if the branch is not `develop`. This means the contracts tests will run if you open a PR where the *source* branch is `develop` regardless of what the target branch is. Typically, this would be `master`, so this change is effectively disabling the contracts tests unless we are merging to main. 

I did it this way because CircleCI doesn't expose a nice interface for checking the target branch of a PR. We could do it by checking the target branch, but we'd have to use the GitHub CLI to do that, which seems overly complicated to me.