### PR TITLE
fix(core): discard git message when user is not in a git repository

### DIFF
--- a/.changeset/old-ladybugs-cross.md
+++ b/.changeset/old-ladybugs-cross.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Remove git output when user isn't in a git repository

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,8 @@
     "yesno": "^0.4.0"
   },
   "devDependencies": {
-    "chai": "^4.3.8"
+    "@types/sinon": "^17.0.2",
+    "chai": "^4.3.8",
+    "sinon": "^17.0.1"
   }
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1205,7 +1205,12 @@ export const assertValidProjectName = (input: string): void => {
 export const getCurrentGitCommitHash = (): string | null => {
   let commitHash: string
   try {
-    commitHash = execSync('git rev-parse HEAD').toString().trim()
+    // Get the current git commit. We call this command with "2>/dev/null" to discard the `stderr`.
+    // If we don't discard the `stderr`, the following statement would be displayed to the user if
+    // they aren't in a git repository:
+    //
+    // "fatal: not a git repository (or any of the parent directories): .git".
+    commitHash = execSync('git rev-parse HEAD 2>/dev/null').toString().trim()
   } catch {
     return null
   }

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -1,8 +1,16 @@
+import child_process from 'child_process'
+
 import { expect } from 'chai'
 import { ethers } from 'ethers'
 import { recursivelyConvertResult } from '@sphinx-labs/contracts'
+import sinon from 'sinon'
 
-import { arraysEqual, equal, formatSolcLongVersion } from '../src/utils'
+import {
+  arraysEqual,
+  equal,
+  formatSolcLongVersion,
+  getCurrentGitCommitHash,
+} from '../src/utils'
 
 describe('Utils', () => {
   describe('equal', () => {
@@ -537,6 +545,35 @@ describe('Utils', () => {
       const version = '0.8.23+commit.f704f362.Darwin.appleclang'
       const formattedVersion = formatSolcLongVersion(version)
       expect(formattedVersion).to.equal('0.8.23+commit.f704f362')
+    })
+  })
+
+  describe('getCurrentGitCommitHash', () => {
+    it('should not output to stderr when execSync fails', () => {
+      const execSyncStub = sinon.stub(child_process, 'execSync')
+      execSyncStub.throws(new Error('execSync failed'))
+      const result = getCurrentGitCommitHash()
+
+      // Check that `execSync` was called with "2>/dev/null", discards the `stderr`. We do this
+      // instead of explicitly checking that nothing was written to `stderr` since because
+      // overriding `stderr` would require a more complex setup involving a spy or mock on the
+      // stderr stream itself, which is outside the scope of typical unit testing practices.
+      sinon.assert.calledWith(execSyncStub, 'git rev-parse HEAD 2>/dev/null')
+
+      expect(result).to.be.null
+
+      execSyncStub.restore()
+    })
+
+    it('should return a commit hash when in a git repository', () => {
+      const commitHash = getCurrentGitCommitHash()
+
+      // Narrow the TypeScript type.
+      if (typeof commitHash !== 'string') {
+        throw new Error(`Git commit hash isn't a string.`)
+      }
+
+      expect(commitHash.length).equals(40)
     })
   })
 })


### PR DESCRIPTION
Fixes an issue where the following line was displayed to the user if they aren't in a git repository:
> "fatal: not a git repository (or any of the parent directories): .git".

I manually checked that there this error message isn't displayed in a repo that doesn't have git