### PR TITLE
fix(pg): Resolve linea transaction hang

### DIFF
--- a/.changeset/slimy-impalas-move.md
+++ b/.changeset/slimy-impalas-move.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Add large gas price pad on linea goerli

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -199,13 +199,19 @@ export const getGasPriceOverrides = async (
     case 1442:
     case 1101:
       return overridden
-    // On linea and its testnet, just override the gasPrice
+    // On linea testnet, 10x the gas price because of this bug:
+    // https://github.com/ethers-io/ethers.js/issues/4533
     case 59140:
+      if (gasPrice !== null) {
+        overridden.gasPrice = gasPrice * BigInt(10)
+        return overridden
+      }
+    // On linea, override the gasPrice
     case 59144:
       if (gasPrice !== null) {
         overridden.gasPrice = gasPrice
-        return overridden
       }
+      return overridden
     // On Polygon PoS, override the maxPriorityFeePerGas using the max fee
     case 137:
       if (maxFeePerGas !== null && maxPriorityFeePerGas !== null) {


### PR DESCRIPTION
## Purpose
Sets the gas price to 10x the recommended value on linea goerli to [workaround this bug](https://github.com/ethers-io/ethers.js/issues/4533).