### PR TITLE
fix(ci): Remove extra tag release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,20 +53,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish Solidity Library
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v5
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        with:
-          script: |
-            const publishedPackages = JSON.parse(process.env.PUBLISHED_PACKAGES);
-            const contractsPackage = publishedPackages.find((pkg) => pkg.name === '@sphinx-labs/contracts');
-            if (contractsPackage) {
-              github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/tags/v${contractsPackage.version}`,
-                sha: context.sha
-              });
-            }


### PR DESCRIPTION
## Purpose
Removes a release workflow step that is not actually necessary. It was added to generate a tag which we would use to install the library using `forge install`, but we're using commit hashes instead of tags so it is not necessary. 