### PR TITLE
fix(core): Ensure required artifacts always included in output selection

### DIFF
--- a/.changeset/lucky-berries-work.md
+++ b/.changeset/lucky-berries-work.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Always include required artifacts in remote compiler output

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -288,6 +288,27 @@ export const getConfigArtifactsRemote = async (
   // Get the compiler output for each compiler input.
   for (const compilerConfig of compilerConfigs) {
     for (const sphinxInput of compilerConfig.inputs) {
+      // Make sure any contracts we need are included in the output selection as long as they are in the input sources
+      for (const actionInput of compilerConfig.actionInputs) {
+        for (const { fullyQualifiedName } of actionInput.contracts) {
+          // Split the contract's fully qualified name into its source name and contract name.
+          const [sourceName] = fullyQualifiedName.split(':')
+          if (sphinxInput.input.sources[sourceName]) {
+            sphinxInput.input.settings.outputSelection[sourceName] = {
+              '': ['ast'],
+              '*': [
+                'abi',
+                'evm.bytecode',
+                'evm.deployedBytecode',
+                'evm.methodIdentifiers',
+                'metadata',
+                'storageLayout',
+              ],
+            }
+          }
+        }
+      }
+
       const solcBuild: SolcBuild = await getSolcBuild(sphinxInput.solcVersion)
       let compilerOutput: CompilerOutput
       if (solcBuild.isSolcJs) {


### PR DESCRIPTION
## Purpose
Fixes an issue where its possible for required compiler artifacts to not be output during remote executor compilation due to the `outputSelection` not including them. 

We might want to consider if there are other implications wrt how we handle the build info files. Maybe we should consider adding the use of `--force` back into the deployment process? 

At a higher level, this sort of bug just adds more to the argument that we should:
- Ensure that the simulation process uses exactly the same logic as the production deployment process
- Consider removing the need to recompile in the DevOps platform at all by including all necessary info in the compiler config