### PR TITLE
fix(pg): Handle prior installation of sphinx library contracts

### DIFF
--- a/.changeset/weak-readers-admire.md
+++ b/.changeset/weak-readers-admire.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Add handling for previously installed incorrect version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ jobs:
           keys:
             - v2-cache-source-{{ .Branch }}-{{ .Revision }}
             - v2-cache-source-{{ .Branch }}
+      - run:
+          name: Git reset
+          command: |
+            git reset --hard
       - checkout
       - run:
           name: Initialize submodules

--- a/packages/plugins/src/cli/setup.ts
+++ b/packages/plugins/src/cli/setup.ts
@@ -1,5 +1,6 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
+import ora from 'ora'
 
 import { init } from '../sample-project'
 import { SphinxContext, makeSphinxContext } from './context'
@@ -142,7 +143,8 @@ export const makeCLI = (
       'Installs the required version of the Sphinx Solidity library contracts',
       (y) => y.usage('Usage: sphinx install'),
       async () => {
-        await handleInstall()
+        const spinner = ora()
+        await handleInstall(spinner)
       }
     )
     .command(

--- a/packages/plugins/src/sample-project/index.ts
+++ b/packages/plugins/src/sample-project/index.ts
@@ -138,9 +138,9 @@ export const init = async (
   // Create a `.env` file that contains the Sphinx API Key and Alchemy API Key supplied by the user.
   fs.writeFileSync('.env', fetchDotEnvFile(sphinxApiKey, alchemyApiKey))
 
-  await handleInstall()
+  spinner.succeed('Initialized sample Sphinx project.')
+
+  await handleInstall(spinner)
 
   await handleCommit()
-
-  spinner.succeed('Initialized sample Sphinx project.')
 }


### PR DESCRIPTION
## Purpose
Updates the `sphinx install` command to handle cases where an old version of the Sphinx library was installed by removing it before then installing the required version.

## Testing
I replicated this issue with the following steps:
1. Run through the quickstart with the currently released packages
2. Create a new branch in the sphinx repo `v0.18.0-test` (or any name that does not include `@`)
3. Push the branch to github
4. Run `forge install sphinx-labs/sphinx@v0.18.0-test`

Note that this issue only occurs if the branch you want to install was not on GitHub when you first installed the sphinx library during the quickstart. I tested this fix quite extensively and confirmed the `install` command works in the following scenarios in addition to resolving the bug itself:
- the library is not installed at all
- the library is installed, but the `lib` or `lib/sphinx` folder has been deleted
- there are staged or unstaged changes in the users repo