### PR TITLE
fix(ct): Bump forge-std library

### DIFF
--- a/.changeset/dry-worms-hang.md
+++ b/.changeset/dry-worms-hang.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/contracts': patch
+---
+
+Bump forge-std


### PR DESCRIPTION
## Purpose
Reinstalls the `forge-std` library. To be honest, I'm not exactly sure why this is necessary but I found that building on the `develop` branch resulted in this getting reinstalled. We should keep an eye out for this happening again. It might indicate a problem with our current dependency setup.