### PR TITLE
fix(core): merge compiler inputs based on build info ID instead of solc version

### DIFF
--- a/.changeset/curvy-nails-end.md
+++ b/.changeset/curvy-nails-end.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Merge compiler inputs based on build info ID instead of solc version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,6 @@ jobs:
           keys:
             - v2-cache-source-{{ .Branch }}-{{ .Revision }}
             - v2-cache-source-{{ .Branch }}
-      - run:
-          name: Git reset
-          command: |
-            git reset --hard
       - checkout
       - run:
           name: Initialize submodules

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -22,8 +22,11 @@ export const getParsedConfigWithCompilerInputs = (
           throw new Error(`Could not find artifact for: ${fullyQualifiedName}`)
         }
 
+        // Check if we've already added the current build info to the inputs array. If we have,
+        // we'll merge the new sources into the existing sources. Otherwise, we'll create a new
+        // element in the inputs array.
         const prevSphinxInput = sphinxInputs.find(
-          (input) => input.solcLongVersion === buildInfo.solcLongVersion
+          (input) => input.id === buildInfo.id
         )
 
         const { language, settings, sources } = getMinimumCompilerInput(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -334,7 +334,9 @@ export const getConfigArtifactsRemote = async (
         const [sourceName, contractName] = fullyQualifiedName.split(':')
 
         const buildInfo = solcArray.find(
-          (e) => e.output.contracts[sourceName][contractName]
+          // We use the optional chaining operator so that this line doesn't throw an error if
+          // `contracts[sourceName]` is undefined.
+          (e) => e.output.contracts[sourceName]?.[contractName]
         )
         if (!buildInfo) {
           throw new Error(


### PR DESCRIPTION
Previously, we were combining contract sources from different build info files as long as the build info files had the same `solcLongVersion`. This was problematic because different build info files can contain different compiler settings. This PR fixes this issue by only combining sources from the _same_ build info file. We identify each build info file according to its `id` field.

I manually tested that this fixes the issue in the "Steps to reproduce" section of the [ticket for this issue](https://linear.app/chugsplash/issue/CHU-445/fix-code-in-the-plugin-that-creates-the-sphinxinputs-array).