### PR TITLE
chore(deps): bump forge-std and use Sphinx fork of Foundry

### DIFF
--- a/.changeset/empty-beers-breathe.md
+++ b/.changeset/empty-beers-breathe.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/contracts': patch
+---
+
+Bump forge-std and use Sphinx fork of Foundry

--- a/ops/ci-builder/Dockerfile
+++ b/ops/ci-builder/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 WORKDIR /opt/foundry
 
 RUN source $HOME/.profile && \
-    cargo install --git https://github.com/foundry-rs/foundry#490b588244a149453e7c6f55641fad89d30b0754 \
+    cargo install --git https://github.com/sphinx-labs/foundry#fcb7c1e83402692ccf5bcec50238ded71320d1e0 \
       --profile local forge cast chisel anvil && \
     strip $HOME/.cargo/bin/forge && \
     strip $HOME/.cargo/bin/cast && \


### PR DESCRIPTION
The new `forge-std` version contains the `AccountAccess` structs, which are used in the state diff.