### PR TITLE
docs: fix npm sphinx installation command

### DIFF
--- a/docs/cli-existing-project.md
+++ b/docs/cli-existing-project.md
@@ -81,7 +81,7 @@ yarn sphinx install
 
 npm:
 ```
-npm sphinx install
+npx sphinx install
 ```
 
 pnpm:


### PR DESCRIPTION
I checked that there's only one instance of this mistake in the monorepo (including user-facing docs and TypeScript logic)