### PR TITLE
fix(ci): Reset in ci and handle failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           keys:
             - v2-cache-source-{{ .Branch }}-{{ .Revision }}
             - v2-cache-source-{{ .Branch }}
+      - run:
+          name: Reset Head
+          command: git reset --hard || true
       - checkout
       - run:
           name: Initialize submodules


### PR DESCRIPTION
## Purpose
Adds back in the `git reset --hard` step, but this time the step failing will not cause the whole CI process to fail. 