### PR TITLE
fix(pg): resolve 'max depth exceeded' error for large deployments

### DIFF
--- a/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
+++ b/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
@@ -77,8 +77,20 @@ struct ParsedAccountAccess {
 
 /**
  * @notice Contains all of the information that's collected in a deployment on a single chain.
+ *         The only difference between this struct and the TypeScript `DeploymentInfo` object is
+ *         that the latter has an `accountAccesses` array of `ParsedAccountAccess` elements, whereas
+ *         this struct has an `encodedAccountAccesses` bytes array of `ParsedAccountAccess`
+ *         elements.
+ *
+ * @custom:field encodedAccountAccesses An array of ABI encoded `ParsedAccountAccess` structs. We
+ *                                      ABI encode each `ParsedAccountAccess` struct individually so
+ *                                      that we can decode them in TypeScript. Specifically, if we
+ *                                      ABI encode the entire array of `ParsedAccountAccess`
+ *                                      elements, the encoded bytes will be too large for EthersJS
+ *                                      to ABI decode, which causes an error. This occurs for large
+ *                                      deployments, i.e. greater than 50 contracts.
  */
-struct DeploymentInfo {
+struct FoundryDeploymentInfo {
     address safeAddress;
     address moduleAddress;
     address executorAddress;
@@ -92,7 +104,7 @@ struct DeploymentInfo {
     InitialChainState initialState;
     bool arbitraryChain;
     string sphinxLibraryVersion;
-    ParsedAccountAccess[] accountAccesses;
+    bytes[] encodedAccountAccesses;
     uint256[] gasEstimates;
 }
 
@@ -201,12 +213,22 @@ contract SphinxPluginTypes {
         )
     {}
 
-    function getDeploymentInfo() external view returns (DeploymentInfo memory deploymentInfo) {}
+    function parsedAccountAccessType()
+        external
+        view
+        returns (ParsedAccountAccess memory parsedAccountAccess)
+    {}
+
+    function getDeploymentInfo()
+        external
+        view
+        returns (FoundryDeploymentInfo memory deploymentInfo)
+    {}
 
     function getDeploymentInfoArray()
         external
         view
-        returns (DeploymentInfo[] memory deploymentInfoArray)
+        returns (FoundryDeploymentInfo[] memory deploymentInfoArray)
     {}
 
     function sphinxConfigType() external view returns (SphinxConfig memory sphinxConfig) {}

--- a/packages/contracts/test/SphinxUtils.t.sol
+++ b/packages/contracts/test/SphinxUtils.t.sol
@@ -10,6 +10,9 @@ import {
     ContractKindEnum,
     ParsedCallAction,
     Network,
+    InitialChainState,
+    FoundryDeploymentInfo,
+    SphinxConfig,
     ParsedAccountAccess
 } from "../contracts/foundry/SphinxPluginTypes.sol";
 
@@ -173,6 +176,65 @@ contract SphinxUtils_Test is Test, SphinxUtils {
         assertEq(parsed[1].root.kind, VmSafe.AccountAccessKind.Create);
         assertEq(parsed[1].nested.length, 0);
     }
+
+    /**
+     * @notice Check that the serialization function starts with a fresh state for the object key.
+     *         This ensures existing items in the object key aren't included in the serialized JSON.
+     *         We enforce this by including `vm.serializeJson(objKey, "{}")` at the beginning of the
+     *         serialization function.
+     */
+    function test_serializeInitialChainState_success_clearsObjectKey() external {
+        InitialChainState memory initialState;
+        // Add an item to the object key, which is the same object key used in the serialization
+        // function.
+        string memory serialized = vm.serializeString(initialStateKey, "myKey", "myVal");
+        // Check that the item has been added.
+        assertTrue(vm.keyExists(serialized, ".myKey"));
+
+        serialized = serializeInitialChainState(initialState);
+        // Check that the item no longer exists in the JSON.
+        assertFalse(vm.keyExists(serialized, ".myKey"));
+    }
+
+    /**
+     * @notice Check that the serialization function starts with a fresh state for the object key.
+     *         This ensures existing items in the object key aren't included in the serialized JSON.
+     *         We enforce this by including `vm.serializeJson(objKey, "{}")` at the beginning of the
+     *         serialization function.
+     */
+    function test_serializeFoundryDeploymentInfo_success_clearsObjectKey() external {
+        FoundryDeploymentInfo memory deploymentInfo;
+        // Add an item to the object key, which is the same object key used in the serialization
+        // function.
+        string memory serialized = vm.serializeString(deploymentInfoKey, "myKey", "myVal");
+        // Check that the item has been added.
+        assertTrue(vm.keyExists(serialized, ".myKey"));
+
+        serialized = serializeFoundryDeploymentInfo(deploymentInfo);
+        // Check that the item no longer exists in the JSON.
+        assertFalse(vm.keyExists(serialized, ".myKey"));
+    }
+
+    /**
+     * @notice Check that the serialization function starts with a fresh state for the object key.
+     *         This ensures existing items in the object key aren't included in the serialized JSON.
+     *         We enforce this by including `vm.serializeJson(objKey, "{}")` at the beginning of the
+     *         serialization function.
+     */
+    function test_serializeSphinxConfig_success_clearsObjectKey() external {
+        SphinxConfig memory sphinxConfig;
+        // Add an item to the object key, which is the same object key used in the serialization
+        // function.
+        string memory serialized = vm.serializeString(sphinxConfigKey, "myKey", "myVal");
+        // Check that the item has been added.
+        assertTrue(vm.keyExists(serialized, ".myKey"));
+
+        serialized = serializeSphinxConfig(sphinxConfig);
+        // Check that the item no longer exists in the JSON.
+        assertFalse(vm.keyExists(serialized, ".myKey"));
+    }
+
+    /////////////////////////////////// Helpers //////////////////////////////////////
 
     function makeAccountAccess(
         address _accessor,

--- a/packages/demo/foundry.toml
+++ b/packages/demo/foundry.toml
@@ -5,7 +5,7 @@ build_info = true
 extra_output = ['storageLayout']
 fs_permissions=[{access="read", path="./out"}, {access="read-write", path="./cache"}]
 allow_paths = ["../.."]
-always_use_create_2_factory=true
+always_use_create_2_factory = true
 remappings=[
   'forge-std/=node_modules/forge-std/src/',
   'ds-test/=node_modules/ds-test/src/',

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -188,9 +188,9 @@ export const deploy = async (
     process.exit(1)
   }
 
-  const abiEncodedDeploymentInfo = readFileSync(deploymentInfoPath, 'utf-8')
+  const serializedDeploymentInfo = readFileSync(deploymentInfoPath, 'utf-8')
   const deploymentInfo = decodeDeploymentInfo(
-    abiEncodedDeploymentInfo,
+    serializedDeploymentInfo,
     sphinxPluginTypesInterface
   )
 

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -138,9 +138,9 @@ export const buildParsedConfigArray: BuildParsedConfigArray = async (
       process.exit(1)
     }
 
-    const abiEncodedDeploymentInfo = readFileSync(deploymentInfoPath, 'utf-8')
+    const serializedDeploymentInfo = readFileSync(deploymentInfoPath, 'utf-8')
     const deploymentInfo = decodeDeploymentInfo(
-      abiEncodedDeploymentInfo,
+      serializedDeploymentInfo,
       sphinxPluginTypesInterface
     )
 


### PR DESCRIPTION
Removes the "max depth exceeded" error described in the [previous PR](https://github.com/sphinx-labs/sphinx/pull/1415), which was happening when ABI decoding a large `DeploymentInfo` object. Now, we serialize the `DeploymentInfo` struct to JSON in Solidity instead of ABI encoding it.

This PR uses the `vm.serialize*` cheatcodes extensively, which are pretty unintuitive IMO. Here's a brief overview of the cheatcodes, which should hopefully save you some time.

Each `vm.serialize` cheatcode is in the format `vm.serialize(<object_key>, <value_key>, <value>)`.
* `<object_key>`: An arbitrary string that Foundry uses internally to store the JSON in memory. This key is *not* part of the actual JSON.
* `<value_key>`: An arbitary string, which is an actual key in the JSON.
* `<value>`: The value of the `<value_key>`.

Here's an example to illustrate:
```
string memory objKey = "myObjKey";
string memory json = vm.serializeUint(objKey, "myValueKey", "myVal"); // Creates: "myObjKey: { myValueKey: "myVal" }
console.log(json) // Logs "{ myValueKey: "myVal" }". Notice that "myObjKey" is not in the JSON.
```

Here are the [Foundry docs](https://book.getfoundry.sh/cheatcodes/serialize-json) for the `serializeJson` cheatcodes.
