### PR TITLE
feat(pg): Track compiler config major version

### DIFF
--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -191,12 +191,15 @@ interface AbstractActionInput extends SphinxTransaction {
   index: string
 }
 
+export const COMPILER_CONFIG_VERSION = '0.1.0'
+
 /**
  * Config object with added compilation details. Must add compilation details to the config before
  * the config can be published or off-chain tooling won't be able to re-generate the deployment.
  */
 export interface CompilerConfig extends ParsedConfig {
   inputs: Array<CompilerInput>
+  version: string
 }
 
 export type ConfigArtifacts = {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -1,7 +1,12 @@
 import * as dotenv from 'dotenv'
 import { DeploymentData, SphinxTransaction } from '@sphinx-labs/contracts'
 
-import { ConfigArtifacts, CompilerConfig, ParsedConfig } from '../config/types'
+import {
+  ConfigArtifacts,
+  CompilerConfig,
+  ParsedConfig,
+  COMPILER_CONFIG_VERSION,
+} from '../config/types'
 import { CompilerInput, getMinimumCompilerInput } from '../languages'
 
 // Load environment variables from .env
@@ -58,6 +63,7 @@ export const getParsedConfigWithCompilerInputs = (
     const compilerConfig: CompilerConfig = {
       ...parsedConfig,
       inputs: sphinxInputs,
+      version: COMPILER_CONFIG_VERSION,
     }
 
     compilerConfigs.push(compilerConfig)

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -49,6 +49,7 @@ import {
   Create2ActionInput,
   ActionInputType,
   CreateActionInput,
+  COMPILER_CONFIG_VERSION,
 } from './config/types'
 import {
   ProposalRequest,
@@ -522,6 +523,7 @@ export const storeCanonicalConfig: StoreCanonicalConfig = async (
       apiKey,
       orgId,
       configData,
+      version: COMPILER_CONFIG_VERSION,
     })
     .catch((err) => {
       if (err.response) {


### PR DESCRIPTION
## Purpose
Adds a version number to the compiler config which is supplied to the website when the config is pinned. 

## Context
I’m adding logic to the website to ensure that we never accidentally attempt execute a compiler config which is not compatible with the current version of the executor. 

I also decided to make this release backwards compatible. We can do this by running two versions of the executor, one of the current version of the plugin, and one for the updated version. I decided to do this because Mean finance is currently in the process of doing some deployments using the old format and I would like those to go smoothly. I think this is the best way to do that. Once Mean Finance is done with their deployments, we will drop support for the old compiler config version. I also think this is good practice for when we inevitably have to do this while supporting more users.  