### PR TITLE
fix(pg): handle different path formats when asserting no linked libraries

### DIFF
--- a/.changeset/nice-planets-smoke.md
+++ b/.changeset/nice-planets-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Handle absolute paths when asserting no linked libraries

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -1,4 +1,4 @@
-import path, { basename, dirname, join } from 'path'
+import path, { basename, dirname, join, relative } from 'path'
 import { promisify } from 'util'
 import {
   createReadStream,
@@ -314,7 +314,7 @@ export const assertNoLinkedLibraries = async (
       // that there's a single fully qualified name in the array returned by
       // `findFullyQualifiedNames` because the user's Forge script was executed successfully before
       // this function was called, which means there must only be a single contract.
-      findFullyQualifiedNames(scriptPath, cachePath)[0]
+      findFullyQualifiedNames(scriptPath, cachePath, projectRoot)[0]
   const artifact = await readContractArtifact(
     fullyQualifiedName,
     projectRoot,
@@ -339,10 +339,15 @@ export const assertNoLinkedLibraries = async (
  * qualified name in any of the cached build info files.
  */
 const findFullyQualifiedNames = (
-  sourceName: string,
-  cachePath: string
+  rawSourceName: string,
+  cachePath: string,
+  projectRoot: string
 ): Array<string> => {
   const buildInfoCacheFilePath = join(cachePath, 'sphinx-cache.json')
+
+  // Normalize the source name so that it conforms to the format of the fully qualified names in the
+  // build info cache. The normalized format is "path/to/file.sol".
+  const sourceName = relative(projectRoot, rawSourceName)
 
   const buildInfoCache: Record<string, BuildInfoCacheEntry> = JSON.parse(
     readFileSync(buildInfoCacheFilePath, 'utf8')

--- a/packages/plugins/test/mocha/foundry/utils.spec.ts
+++ b/packages/plugins/test/mocha/foundry/utils.spec.ts
@@ -832,5 +832,31 @@ describe('Utils', async () => {
         )
       ).to.eventually.be.fulfilled
     })
+
+    it('succeeds if sourceName is an absolute path and does not contain linked library', async () => {
+      const sourceName = resolve('contracts/test/SimpleStorage.sol')
+
+      await expect(
+        assertNoLinkedLibraries(
+          sourceName,
+          foundryToml.cachePath,
+          foundryToml.artifactFolder,
+          projectRoot
+        )
+      ).to.eventually.be.fulfilled
+    })
+
+    it('succeeds if sourceName starts with a period and does not contain linked library', async () => {
+      const sourceName = './contracts/test/SimpleStorage.sol'
+
+      await expect(
+        assertNoLinkedLibraries(
+          sourceName,
+          foundryToml.cachePath,
+          foundryToml.artifactFolder,
+          projectRoot
+        )
+      ).to.eventually.be.fulfilled
+    })
   })
 })


### PR DESCRIPTION
Catches a bug where the `findFullyQualifiedNames` function wasn't normalizing the `scriptPath` entered by the user, which prevented it from finding the corresponding fully qualified name(s) in the build info cache. This bug applied to paths starting with a period (e.g. "./path/to/file.sol") or absolute paths. This PR resolves the bug by calling `path.relative` in `findFullyQualifiedNames` to normalize the path to be in the format "path/to/file.sol", which matches the format of the fully qualified names.