### PR TITLE
fix(core): move COMPILER_CONFIG_VERSION const location

### DIFF
--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -191,8 +191,6 @@ interface AbstractActionInput extends SphinxTransaction {
   index: string
 }
 
-export const COMPILER_CONFIG_VERSION = '0.1.0'
-
 /**
  * Config object with added compilation details. Must add compilation details to the config before
  * the config can be published or off-chain tooling won't be able to re-generate the deployment.

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -8,6 +8,8 @@ import {
 
 export type SupportedLocalNetworkName = 'anvil'
 
+export const COMPILER_CONFIG_VERSION = '0.1.0'
+
 /**
  * Data returned by the `anvil_metadata` and `hardhat_metadata` RPC methods.
  *

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -1,13 +1,9 @@
 import * as dotenv from 'dotenv'
 import { DeploymentData, SphinxTransaction } from '@sphinx-labs/contracts'
 
-import {
-  ConfigArtifacts,
-  CompilerConfig,
-  ParsedConfig,
-  COMPILER_CONFIG_VERSION,
-} from '../config/types'
+import { ConfigArtifacts, CompilerConfig, ParsedConfig } from '../config/types'
 import { CompilerInput, getMinimumCompilerInput } from '../languages'
+import { COMPILER_CONFIG_VERSION } from '../networks'
 
 // Load environment variables from .env
 dotenv.config()

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -49,7 +49,6 @@ import {
   Create2ActionInput,
   ActionInputType,
   CreateActionInput,
-  COMPILER_CONFIG_VERSION,
 } from './config/types'
 import {
   ProposalRequest,
@@ -60,7 +59,7 @@ import { ExecutionMode, RELAYER_ROLE } from './constants'
 import { SphinxJsonRpcProvider } from './provider'
 import { BuildInfo, CompilerOutput } from './languages/solidity/types'
 import { getSolcBuild } from './languages'
-import { LocalNetworkMetadata } from './networks'
+import { COMPILER_CONFIG_VERSION, LocalNetworkMetadata } from './networks'
 import { RelayProposal, StoreCanonicalConfig } from './types'
 
 export const sphinxLog = (


### PR DESCRIPTION
## Purpose
Moves the location of the `COMPILER_CONFIG_VERSION` constant so it can be imported by the website.