### PR TITLE
fix(pg): prevent Foundry from serializing strings as numbers

### DIFF
--- a/.changeset/lovely-ants-agree.md
+++ b/.changeset/lovely-ants-agree.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Prevent Foundry from serializing strings as numbers

--- a/packages/contracts/contracts/foundry/SphinxUtils.sol
+++ b/packages/contracts/contracts/foundry/SphinxUtils.sol
@@ -976,8 +976,8 @@ contract SphinxUtils is SphinxConstants, StdUtils {
 
     /**
      * @notice Serializes the `FoundryDeploymentInfo` struct. The serialized string is the
-     *         same structure as the `FoundryDeploymentInfo` struct except all `uint` fields
-     *         are ABI encoded (see inline docs for details).
+     *         same structure as the `FoundryDeploymentInfo` struct except all `uint` and `string`
+     *         fields are ABI encoded (see inline docs for details).
      */
     function serializeFoundryDeploymentInfo(
         FoundryDeploymentInfo memory _deployment
@@ -992,11 +992,6 @@ contract SphinxUtils is SphinxConstants, StdUtils {
         vm.serializeAddress(deploymentInfoKey, "executorAddress", _deployment.executorAddress);
         vm.serializeBytes(deploymentInfoKey, "safeInitData", _deployment.safeInitData);
         vm.serializeBool(deploymentInfoKey, "requireSuccess", _deployment.requireSuccess);
-        vm.serializeString(
-            deploymentInfoKey,
-            "sphinxLibraryVersion",
-            _deployment.sphinxLibraryVersion
-        );
         vm.serializeBool(deploymentInfoKey, "arbitraryChain", _deployment.arbitraryChain);
         vm.serializeBytes(
             deploymentInfoKey,
@@ -1022,6 +1017,15 @@ contract SphinxUtils is SphinxConstants, StdUtils {
         );
         // Serialize the gas estimates as an ABI encoded `uint256` array.
         vm.serializeBytes(deploymentInfoKey, "gasEstimates", abi.encode(_deployment.gasEstimates));
+        // Serialize the Sphinx library version as an ABI encoded string. We ABI encode it to ensure
+        // that Foundry doesn't serialize it as a number, which will happen if the
+        // `sphinxLibraryVersion` consists only of numbers. If Foundry serializes it as a number,
+        // it'll be prone to the same precision loss due to JavaScript's low integer size limit.
+        vm.serializeBytes(
+            deploymentInfoKey,
+            "sphinxLibraryVersion",
+            abi.encode(_deployment.sphinxLibraryVersion)
+        );
 
         // Serialize structs
         vm.serializeString(
@@ -1043,11 +1047,12 @@ contract SphinxUtils is SphinxConstants, StdUtils {
         // stored in memory for the object key.
         vm.serializeJson(sphinxConfigKey, "{}");
 
-        vm.serializeString(sphinxConfigKey, "projectName", config.projectName);
         vm.serializeAddress(sphinxConfigKey, "owners", config.owners);
         vm.serializeString(sphinxConfigKey, "mainnets", convertNetworksToStrings(config.mainnets));
         vm.serializeString(sphinxConfigKey, "testnets", convertNetworksToStrings(config.testnets));
-        vm.serializeString(sphinxConfigKey, "orgId", config.orgId);
+        // Serialize the string values as ABI encoded strings.
+        vm.serializeBytes(sphinxConfigKey, "projectName", abi.encode(config.projectName));
+        vm.serializeBytes(sphinxConfigKey, "orgId", abi.encode(config.orgId));
         // Serialize the `uint` values as ABI encoded bytes.
         vm.serializeBytes(sphinxConfigKey, "saltNonce", abi.encode(config.saltNonce));
         string memory finalJson = vm.serializeBytes(

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -29,7 +29,7 @@ export type LocalNetworkMetadata = {
   snapshots?: Record<string, unknown>
 }
 
-export const networkEnumToName = (networkEnum: bigint | string) => {
+export const networkEnumToName = (networkEnum: bigint | string | number) => {
   const networkEnumBigInt = BigInt(networkEnum)
 
   const network = SPHINX_NETWORKS.find(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1644,3 +1644,10 @@ export const isCreateActionInput = (
 export const isFile = (path: string): boolean => {
   return fs.existsSync(path) && fs.statSync(path).isFile()
 }
+
+/**
+ * Returns `true` if the given address is a hex-prefixed, checksummed address.
+ */
+export const isNormalizedAddress = (addr: string): boolean => {
+  return ethers.getAddress(addr) === addr
+}

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -24,6 +24,7 @@ import {
   getBytesLength,
   getNetworkNameForChainId,
   isDefined,
+  isNormalizedAddress,
   sortHexStrings,
   spawnAsync,
   zeroOutLibraryReferences,
@@ -33,10 +34,13 @@ import {
   AccountAccessKind,
   ActionInput,
   ConfigArtifacts,
+  DeploymentInfo,
   GetConfigArtifacts,
+  InitialChainState,
   ParsedAccountAccess,
   ParsedConfig,
   ParsedVariable,
+  SphinxConfig,
   SphinxConfigWithAddresses,
 } from '@sphinx-labs/core/dist/config/types'
 import { parse } from 'semver'
@@ -47,6 +51,7 @@ import { pick } from 'stream-json/filters/Pick'
 import { streamObject } from 'stream-json/streamers/StreamObject'
 import { streamValues } from 'stream-json/streamers/StreamValues'
 import {
+  ExecutionMode,
   ParsedContractDeployment,
   SphinxJsonRpcProvider,
   networkEnumToName,
@@ -1358,4 +1363,107 @@ export const assertSphinxFoundryForkInstalled = async (
         `foundryup --repo sphinx-labs/foundry --branch sphinx-patch-v0.1.0`
     )
   }
+}
+
+export const isDeploymentInfo = (obj: any): obj is DeploymentInfo => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    isNormalizedAddress(obj.safeAddress) &&
+    isNormalizedAddress(obj.moduleAddress) &&
+    typeof obj.requireSuccess === 'boolean' &&
+    isNormalizedAddress(obj.executorAddress) &&
+    typeof obj.nonce === 'string' &&
+    typeof obj.chainId === 'string' &&
+    typeof obj.blockGasLimit === 'string' &&
+    typeof obj.safeInitData === 'string' &&
+    isSphinxConfig(obj.newConfig) &&
+    isExecutionMode(obj.executionMode) &&
+    isInitialChainState(obj.initialState) &&
+    typeof obj.arbitraryChain === 'boolean' &&
+    typeof obj.sphinxLibraryVersion === 'string' &&
+    Array.isArray(obj.accountAccesses) &&
+    obj.accountAccesses.every(isParsedAccountAccess) &&
+    Array.isArray(obj.gasEstimates) &&
+    obj.gasEstimates.every((e) => typeof e === 'string')
+  )
+}
+
+const isSphinxConfig = (obj: any): obj is SphinxConfig => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.projectName === 'string' &&
+    typeof obj.orgId === 'string' &&
+    Array.isArray(obj.owners) &&
+    obj.owners.every((o) => isNormalizedAddress(o)) &&
+    Array.isArray(obj.mainnets) &&
+    obj.mainnets.every((m) => typeof m === 'string') &&
+    Array.isArray(obj.testnets) &&
+    obj.testnets.every((t) => typeof t === 'string') &&
+    typeof obj.threshold === 'string' &&
+    typeof obj.saltNonce === 'string'
+  )
+}
+
+const isExecutionMode = (obj: any): obj is ExecutionMode => {
+  return Object.values(ExecutionMode).includes(obj)
+}
+
+const isInitialChainState = (obj: any): obj is InitialChainState => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.isSafeDeployed === 'boolean' &&
+    typeof obj.isModuleDeployed === 'boolean' &&
+    typeof obj.isExecuting === 'boolean'
+  )
+}
+
+const isParsedAccountAccess = (obj: any): obj is ParsedAccountAccess => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    isAccountAccess(obj.root) &&
+    Array.isArray(obj.nested) &&
+    obj.nested.every(isAccountAccess)
+  )
+}
+
+const isAccountAccess = (obj: any): obj is AccountAccess => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.chainInfo === 'object' &&
+    obj.chainInfo !== null &&
+    typeof obj.chainInfo.forkId === 'string' &&
+    typeof obj.chainInfo.chainId === 'string' &&
+    Object.values(AccountAccessKind).includes(obj.kind) &&
+    typeof obj.account === 'string' &&
+    typeof obj.accessor === 'string' &&
+    typeof obj.initialized === 'boolean' &&
+    typeof obj.oldBalance === 'string' &&
+    typeof obj.newBalance === 'string' &&
+    typeof obj.deployedCode === 'string' &&
+    typeof obj.value === 'string' &&
+    typeof obj.data === 'string' &&
+    typeof obj.reverted === 'boolean' &&
+    Array.isArray(obj.storageAccesses) &&
+    obj.storageAccesses.every(isStorageAccess)
+  )
+}
+
+const isStorageAccess = (
+  obj: any
+): obj is AccountAccess['storageAccesses'][number] => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.account === 'string' &&
+    typeof obj.slot === 'string' &&
+    typeof obj.isWrite === 'boolean' &&
+    typeof obj.previousValue === 'string' &&
+    typeof obj.newValue === 'string' &&
+    typeof obj.reverted === 'boolean'
+  )
 }


### PR DESCRIPTION
Foundry converts strings like `projectName` to integers if the string contains all numbers. This is a [bug in Foundry](https://github.com/foundry-rs/foundry/issues/6533).

We now ABI encode all string fields in the `DeploymentInfo` object when we serialize it in Solidity. Then, in the TypeScript `decodeDeploymentInfo` function, we ABI decode the strings. We ABI encode the strings to ensure that Foundry doesn't serialize them as numbers, which could cause them to lose precision due to JavaScript's relatively low integer size limit.

Notes:
* I manually checked that every field in the `DeploymentInfo` will convert to its correct type
* Created a type predicate, `isDeploymentInfo`, to enforce that the fields are the correct type
