### PR TITLE
fix(pg): Recommend using github action in CI

### DIFF
--- a/.changeset/witty-kids-shop.md
+++ b/.changeset/witty-kids-shop.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Recommend using github action in CI

--- a/docs/ci-proposals.md
+++ b/docs/ci-proposals.md
@@ -2,9 +2,7 @@
 
 It's a best practice to propose deployments from a CI process instead of using the command line. This ensures that your deployments are reproducible and don't depend on a single developer's machine, which can be a source of bugs.
 
-This guide will show you how to integrate proposals into your CI process. We'll create two workflows: one that dry runs the proposal when a pull request is opened or updated, and another that proposes the deployment when the pull request is merged.
-
-We'll use GitHub Actions as the CI platform in this guide. You can still follow this guide if you're using a different CI platform, but the exact configuration may be slightly different.
+This guide will show you how to integrate proposals into your GitHub Actions CI process. Currently, Sphinx only officially supports GitHub Actions. If you need support for an alternative CI platform, please let us know. In this guide, we'll create two workflows: one that dry runs the proposal when a pull request is opened or updated, and another that proposes the deployment when the pull request is merged.
 
 > Important: Sphinx will propose all transactions that are broadcasted by Foundry. By default, this is **not idempotent**. If you open a PR after completing a deployment, Sphinx will attempt to re-propose any transactions from your script that can be broadcasted again. In most cases, this is not desirable behavior. To resolve this, we highly recommend making your deployment script idempotent.
 
@@ -77,13 +75,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: sphinx-labs/foundry-toolchain@v1
         with:
           version: nightly
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Install Sphinx Solidity Library
-        run: yarn sphinx install --confirm
+        run: yarn sphinx install --ci
       - name: Dry Run
         run: npx sphinx propose <path/to/your/script.s.sol> --dry-run --networks testnets
 ```
@@ -118,11 +116,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: sphinx-labs/foundry-toolchain@v1
         with:
           version: nightly
       - name: Install Dependencies
         run: yarn --frozen-lockfile
+      - name: Install Sphinx Solidity Library
+        run: yarn sphinx install --ci
       - name: Propose
         run: npx sphinx propose <path/to/your/script.s.sol> --confirm --networks testnets
 ```

--- a/docs/cli-existing-project.md
+++ b/docs/cli-existing-project.md
@@ -41,7 +41,6 @@ In this guide, you'll propose the deployment on the command line and then approv
   * [Foundry](https://book.getfoundry.sh/getting-started/installation)
   * [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/), [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), or [pnpm](https://pnpm.io/installation)
   * [Node Version >=16.16.0](https://nodejs.org/en/download). (Run `node -v` to see your current version).
-  * [Rust Compiler](https://www.rust-lang.org/tools/install)
 
 ## 2. Install Sphinx CLI
 

--- a/docs/cli-quickstart.md
+++ b/docs/cli-quickstart.md
@@ -32,7 +32,6 @@ In this guide, you'll create a sample project, propose it on the command line, a
   * [Foundry](https://book.getfoundry.sh/getting-started/installation)
   * [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/), [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), or [pnpm](https://pnpm.io/installation)
   * [Node Version >=16.16.0](https://nodejs.org/en/download). (Run `node -v` to see your current version).
-  * [Rust Compiler](https://www.rust-lang.org/tools/install)
 
 ## 2. Create a new directory
 

--- a/packages/plugins/src/cli/install/index.ts
+++ b/packages/plugins/src/cli/install/index.ts
@@ -9,27 +9,26 @@ import { sphinxUp } from './sphinxup'
 const installWithUpdate = async (
   spinner: ora.Ora,
   skipLibrary: boolean,
-  confirm: boolean
+  ci: boolean
 ) => {
-  if (!confirm) {
+  if (!ci) {
     await userConfirmation(
       'Would you like to install the Sphinx Foundry fork? This is required to use Sphinx and will replace your existing Foundry installation.\nConfirm? (y\\n):'
     )
-  }
+    const foundryupStatus = await spawnAsync('/bin/bash', [
+      '-c',
+      'curl -L https://foundry.paradigm.xyz | bash',
+    ])
+    if (foundryupStatus.code !== 0) {
+      // The `stdout` contains the trace of the error.
+      console.log(foundryupStatus.stdout)
+      // The `stderr` contains the error message.
+      console.log(foundryupStatus.stderr)
+      process.exit(1)
+    }
 
-  const foundryupStatus = await spawnAsync('/bin/sh', [
-    '-c',
-    'curl -L https://foundry.paradigm.xyz | bash',
-  ])
-  if (foundryupStatus.code !== 0) {
-    // The `stdout` contains the trace of the error.
-    console.log(foundryupStatus.stdout)
-    // The `stderr` contains the error message.
-    console.log(foundryupStatus.stderr)
-    process.exit(1)
+    execSync(sphinxUp, { stdio: 'inherit', shell: '/bin/bash' })
   }
-
-  execSync(sphinxUp, { stdio: 'inherit', shell: '/bin/bash' })
 
   if (skipLibrary) {
     return

--- a/packages/plugins/src/cli/setup.ts
+++ b/packages/plugins/src/cli/setup.ts
@@ -145,17 +145,23 @@ export const makeCLI = (
             boolean: true,
             default: false,
           })
-          .option(confirmOption, {
+          .option('ci', {
             describe:
-              'Automatically confirm the Sphinx Foundry fork installation.',
+              'Continuous integration mode (skips installing the Sphinx Foundry fork)',
             boolean: true,
             default: false,
           }),
       async (argv) => {
-        const { skipLibrary, confirm } = argv
+        const { skipLibrary, ci } = argv
+
+        if (skipLibrary && ci) {
+          throw new Error(
+            'Cannot specify both `--skip-library` and `--ci` at the same time.'
+          )
+        }
 
         const spinner = ora()
-        await handleInstall(spinner, skipLibrary, confirm)
+        await handleInstall(spinner, skipLibrary, ci)
       }
     )
     .command(


### PR DESCRIPTION
## Purpose
- Updates the docs to recommend using our [GitHub action](https://github.com/marketplace/actions/sphinx-foundry-toolchain) to install the Foundry fork in CI (note that this does mean other CI platforms than GitHub will not work, but I think that is an acceptable limitation for now).
- Update the `install` command to include the `ci` option that is explicitly intended to be used in CI and completely skips the installation of our fork (because the GitHub action handles this).