### PR TITLE
fix(pg): set max block gas limit in Forge script during collection

### DIFF
--- a/.changeset/twelve-baboons-swim.md
+++ b/.changeset/twelve-baboons-swim.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Set max block gas limit in Forge script during collection

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -27,3 +27,5 @@ export enum ExecutionMode {
   LiveNetworkCLI,
   Platform,
 }
+
+export const MAX_UINT64 = BigInt(2) ** BigInt(64) - BigInt(1)

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -28,6 +28,7 @@ import {
   fetchChainIdForNetwork,
   writeDeploymentArtifacts,
   isLegacyTransactionsRequiredForNetwork,
+  MAX_UINT64,
 } from '@sphinx-labs/core'
 import { red } from 'chalk'
 import ora from 'ora'
@@ -189,7 +190,13 @@ export const deploy = async (
   }
 
   // Collect the transactions.
-  const spawnOutput = await spawnAsync('forge', forgeScriptCollectArgs)
+  const spawnOutput = await spawnAsync('forge', forgeScriptCollectArgs, {
+    // Set the block gas limit to the max amount allowed by Foundry. This overrides lower block
+    // gas limits specified in the user's `foundry.toml`, which can cause the script to run out of
+    // gas. We use the `FOUNDRY_BLOCK_GAS_LIMIT` environment variable because it has a higher
+    // priority than `DAPP_BLOCK_GAS_LIMIT`.
+    FOUNDRY_BLOCK_GAS_LIMIT: MAX_UINT64.toString(),
+  })
 
   if (spawnOutput.code !== 0) {
     spinner.stop()

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -14,6 +14,7 @@ import {
   isLegacyTransactionsRequiredForNetwork,
   SphinxJsonRpcProvider,
   isFile,
+  MAX_UINT64,
 } from '@sphinx-labs/core'
 import ora from 'ora'
 import { blue, red } from 'chalk'
@@ -131,7 +132,13 @@ export const buildParsedConfigArray: BuildParsedConfigArray = async (
     }
 
     // Collect the transactions for the current network.
-    const spawnOutput = await spawnAsync('forge', forgeScriptCollectArgs)
+    const spawnOutput = await spawnAsync('forge', forgeScriptCollectArgs, {
+      // Set the block gas limit to the max amount allowed by Foundry. This overrides lower block
+      // gas limits specified in the user's `foundry.toml`, which can cause the script to run out of
+      // gas. We use the `FOUNDRY_BLOCK_GAS_LIMIT` environment variable because it has a higher
+      // priority than `DAPP_BLOCK_GAS_LIMIT`.
+      FOUNDRY_BLOCK_GAS_LIMIT: MAX_UINT64.toString(),
+    })
 
     if (spawnOutput.code !== 0) {
       spinner?.stop()


### PR DESCRIPTION
Fixes the following edge case:
1. User specifies a `gas_limit` field in their `foundry.toml` ([docs](https://book.getfoundry.sh/reference/config/testing?highlight=gas_limit#gas_limit)). (xkeep3r sets it to 30M)
2. The `gas_limit` is used in the forge script that collects their transactions
3. An "out of gas" error occurs in the collection script

This didn't happen before in keep3r's integration because we used to collect the transactions in a separate Forge script from estimating the Merkle leaf gas. The 'out of gas' error occurs after estimating the Merkle leaf gas.

I manually checked that this fixes the issue in keep3r's integration