### PR TITLE
fix(core): adjust gas heuristics to support large contracts on Scroll

### DIFF
--- a/.changeset/green-cups-train.md
+++ b/.changeset/green-cups-train.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Adjust gas heuristics to support large contracts on Scroll

--- a/packages/contracts/contracts/foundry/Sphinx.sol
+++ b/packages/contracts/contracts/foundry/Sphinx.sol
@@ -388,10 +388,14 @@ abstract contract Sphinx {
             //    more likely to be "warm" (i.e. cheaper) than the production environment, where
             //    transactions may be split between batches.
             //
-            // We chose to multiply the gas by 1.3 because multiplying it by a higher number could
-            // make a very large transaction unexecutable on-chain. Since the 1.3x multiplier
-            // doesn't impact small transactions very much, we add a constant amount of 20k too.
-            gasEstimates[i] = 20_000 + ((startGas - finalGas) * 13) / 10;
+            // Collecting the user's transactions in the same process as this function does not
+            // impact the Merkle leaf gas fields because we use `vm.snapshot`/`vm.revertTo`. Also,
+            // state changes on one fork do not impact the gas cost on other forks.
+            //
+            // We chose to multiply the gas by 1.1 because multiplying it by a higher number could
+            // make a very large transaction unexecutable on-chain. Since the 1.1x multiplier
+            // doesn't impact small transactions very much, we add a constant amount of 60k too.
+            gasEstimates[i] = 60_000 + ((startGas - finalGas) * 11) / 10;
         }
 
         vm.stopPrank();

--- a/packages/core/src/actions/execute.ts
+++ b/packages/core/src/actions/execute.ts
@@ -207,7 +207,7 @@ export const executeBatchActions = async (
   const executionReceipts: ethers.TransactionReceipt[] = []
   const batches: SphinxLeafWithProof[][] = []
 
-  const maxGasLimit = getMaxGasLimit(blockGasLimit)
+  const maxGasLimit = getMaxGasLimit(blockGasLimit, chainId)
 
   // Pull the Merkle root state from the contract so we're guaranteed to be up to date.
   const activeRoot = await sphinxModule.activeMerkleRoot()
@@ -532,7 +532,7 @@ export const executeActionsViaSigner: ExecuteActions = async (
  * Here are the data points in the format (<CALLDATA_LENGTH>, <GAS_ESTIMATE>):
  * (0,10202),(1000,10592),(100000,67166),(500000,676492),(1000000,2296456).
  *
- * After summing these values, we multiply by 1.1 to ensure that the heuristic overestimates the
+ * After summing these values, we include a buffer to ensure that the heuristic overestimates the
  * amount of gas. This ensures we don't underestimate the gas, which would otherwise be a concern
  * because we don't incorporate the cost of executing the `DELEGATECALL` on the `SphinxModuleProxy`,
  * or the cost of potentially returning data from the `exec` function on the `ManagedService`. This
@@ -566,7 +566,7 @@ export const estimateGasViaManagedService: EstimateGas = (
   const estimate =
     21_000 + callDataGas + estimateModuleExecutionGas(batch) + managedServiceGas
 
-  return Math.round(estimate * 1.1)
+  return Math.round(estimate * 1.05 + 50_000) // Include a buffer
 }
 
 /**
@@ -580,7 +580,7 @@ export const estimateGasViaManagedService: EstimateGas = (
  * zero-byte of calldata.
  * 3. The estimated cost of executing the logic in the `SphinxModule`.
  *
- * After summing these values, we multiply by 1.1 to ensure that the heuristic overestimates the
+ * After summing these values, we include a buffer to ensure that the heuristic overestimates the
  * amount of gas. This ensures we don't underestimate the gas, which would otherwise be a concern
  * because we don't incorporate the cost of executing the `DELEGATECALL` on the `SphinxModuleProxy`.
  * This buffer also makes our estimate closer to the value that would be returned by the
@@ -597,7 +597,7 @@ export const estimateGasViaSigner: EstimateGas = (moduleAddress, batch) => {
 
   const estimate = 21_000 + callDataGas + estimateModuleExecutionGas(batch)
 
-  return Math.round(estimate * 1.1)
+  return Math.round(estimate * 1.05 + 50_000) // Include a buffer
 }
 
 /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1436,7 +1436,19 @@ export const getCreate3Salt = (
  * which transactions to include. As a result, we restrict our total gas usage to a fraction of the
  * block gas limit.
  */
-export const getMaxGasLimit = (blockGasLimit: bigint): bigint => {
+export const getMaxGasLimit = (
+  blockGasLimit: bigint,
+  chainId: bigint
+): bigint => {
+  // On Scroll and Scroll Sepolia, set the max gas limit to be 80% of the block gas limit. We set a
+  // higher value for these networks because their block gas limit is low (10 million), which means
+  // a lower max gas limit could cause large contract deployments to be unexecutable. Transactions
+  // that use ~8.5M gas were executed quickly on Scroll Sepolia, so an 80% limit shouldn't
+  // meaningfully impact execution speed.
+  if (chainId === BigInt(534351) || chainId === BigInt(534352)) {
+    return (blockGasLimit * BigInt(8)) / BigInt(10)
+  }
+
   return blockGasLimit / BigInt(2)
 }
 

--- a/packages/plugins/src/foundry/decode.ts
+++ b/packages/plugins/src/foundry/decode.ts
@@ -16,6 +16,7 @@ import {
   decodeDeterministicDeploymentProxyData,
   Create2ActionInput,
   ActionInputType,
+  getNetworkNameForChainId,
 } from '@sphinx-labs/core'
 import { AbiCoder, ConstructorFragment, ethers } from 'ethers'
 import {
@@ -158,8 +159,9 @@ export const makeParsedConfig = (
     const gas = gasEstimates[i].toString()
 
     if (BigInt(gas) > maxAllowedGasPerLeaf) {
+      const networkName = getNetworkNameForChainId(BigInt(chainId))
       throw new Error(
-        `Estimated gas for a transaction is too close to the block gas limit.`
+        `Estimated gas for a transaction is too close to the block gas limit on ${networkName}.`
       )
     }
 

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -410,7 +410,12 @@ export const makeDeployment = async (
         },
         arbitraryChain: false,
         accountAccesses,
-        gasEstimates: new Array(numActionInputs).fill(BigInt(5_000_000)),
+        // We set the Merkle leaf gas fields to 6 million to ensure that a very large contract
+        // deployment can fit in a batch. This is important to check on networks like Scroll which
+        // have low block gas limits. (Scroll's block gas limit is 10 million). A Merkle leaf gas
+        // field of 6 million corresponds to a contract at the max size limit with a couple dozen
+        // SSTOREs in its constructor.
+        gasEstimates: new Array(numActionInputs).fill(BigInt(6_000_000)),
         sphinxLibraryVersion: CONTRACTS_LIBRARY_VERSION,
       }
 


### PR DESCRIPTION
Scroll's block gas limit is 10M. I didn't notice it until now because the simulation contract's gas limit was previously 2 million, and I recently bumped it to 5 million.

A contract near the max size limit was previously not executable on Scroll because of our gas heuristics.

The goal of this PR is to update our gas heuristics to allow large contracts to be deployable on Scroll. The updated heuristics allow us to comfortably deploy a contract at the max size limit with 25 SSTOREs in its constructor. (Specifically, this contract has >1.7M gas of wiggle room). However, I think it's likely that a user will eventually deploy something that's over our new size limit. I think this is most likely to happen when a contract deploys another contract in its constructor, like how our `SphinxModuleProxyFactory` deploys the `SphinxModule` implementation. Although the `SphinxModuleProxyFactory` only uses 4.2M gas as a standard contract deployment, it's easy to imagine a scenario where the child and parent contract are both near the max size, or the parent contract deploys multiple child contracts. Fwiw, if this happens, this deployment could easily surpass Scroll's block size limit too.

Deciding how to update the heuristics is tricky because an error can occur if we overestimate or underestimate any of the heuristics. I feel pretty confident in the new heuristics though.

This PR updates the following heuristics:
* I changed the buffer applied to the Merkle leaf gas field from `1.3 * gas + 20k` to `1.1 * gas + 60k` on all networks. This occurs in the `Sphinx.sol:_sphinxEstimateMerkleLeafGas` function. It's important not to underestimate this value because an underfunded leaf could potentially fail on-chain. However, I'm pretty confident that Foundry will consistently estimate these accurately. Also, if we underestimate this value, the simulation should throw an error because it attempts to execute the actual deployment.
* I changed the buffer for the estimated batch gas cost from `1.1 * estimate` to `1.05 * estimate + 50k` on all networks. This buffer is applied at the end of the TypeScript `estimateGasViaManagedService` function and the `estimateGasViaSigner` function. The sole purpose of these functions is to determine how large to make the batch, so it's totally fine if they're not precise. The main concern is that making them too large will cause our `findMaxBatchSize` function to throw an error because it can't find a valid batch size. I'd be comfortable removing the buffers from these functions entirely because the worst case is that we submit a batch that actually costs e.g. 70% of the block gas limit instead of 66.7%.
* The max batch size limit (i.e. the value returned by the TypeScript `getMaxGasLimit` function) is increased from 50% of the block gas limit to 80% on Scroll only. All other networks stay at 50%. The risk with setting this number close to 100% is that we may attempt to execute a batch that's over the block gas limit if `estimateGasViaManagedService` underestimates the batch gas cost. I kept this number at 50% on other networks because I'm slightly concerned that increasing it could cause transactions to stall on congested networks like Ethereum, or at least be really slow (i.e. minutes per txn). However, I don't have evidence that they'd stall; I only have evidence that they'd be slower:
  * I checked that very large transactions (~20M gas) are slow (but not unreasonably slow) on Sepolia. (between 15s-40s)
  * Kelvin documented that very large transactions are slow (but he doesn't say "unexecutable"): "Approaching the maximum block gas limit can cause transactions to be executed slowly as a result of the algorithms that miners use to select which transactions to include."

I decided to keep the first two heuristic the same across all networks because they'll be more battle tested if they're used everywhere. For example, if there's an edge case where the Merkle leaf gas field is too low, we're more likely to catch this sooner if the same logic is being used on every network.

If you want to understand the nuances of these heuristics, I recommend reading the docs in the relevant functions, which are pretty detailed.

For testing this update: I changed the deployment in `simulate.spec.ts` to use Merkle leaf gas fields of 6 million, which corresponds to a standard contract deployment that uses 5.4M gas.
