### PR TITLE
fix(pg): make simulation more reliable by using less recent block number

### DIFF
--- a/.changeset/clever-vans-yell.md
+++ b/.changeset/clever-vans-yell.md
@@ -1,5 +1,0 @@
----
-'@sphinx-labs/plugins': patch
----
-
-Allow user to send native gas tokens from their Gnosis Safe

--- a/.changeset/hot-frogs-film.md
+++ b/.changeset/hot-frogs-film.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Make simulation more reliable by using less recent block number

--- a/packages/contracts/contracts/foundry/Sphinx.sol
+++ b/packages/contracts/contracts/foundry/Sphinx.sol
@@ -178,6 +178,7 @@ abstract contract Sphinx {
         deploymentInfo.moduleAddress = module;
         deploymentInfo.chainId = block.chainid;
         deploymentInfo.blockGasLimit = block.gaslimit;
+        deploymentInfo.blockNumber = block.number;
         deploymentInfo.safeInitData = sphinxUtils.getGnosisSafeInitializerData(
             sphinxConfig.owners,
             sphinxConfig.threshold

--- a/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
+++ b/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
@@ -97,6 +97,7 @@ struct FoundryDeploymentInfo {
     uint256 nonce;
     uint256 chainId;
     uint256 blockGasLimit;
+    uint256 blockNumber;
     bytes safeInitData;
     bool requireSuccess;
     SphinxConfig newConfig;

--- a/packages/contracts/contracts/foundry/SphinxUtils.sol
+++ b/packages/contracts/contracts/foundry/SphinxUtils.sol
@@ -1010,6 +1010,7 @@ contract SphinxUtils is SphinxConstants, StdUtils {
             "blockGasLimit",
             abi.encode(_deployment.blockGasLimit)
         );
+        vm.serializeBytes(deploymentInfoKey, "blockNumber", abi.encode(_deployment.blockNumber));
         vm.serializeBytes(
             deploymentInfoKey,
             "executionMode",

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -77,6 +77,7 @@ export type ParsedConfig = {
   nonce: string
   chainId: string
   blockGasLimit: string
+  blockNumber: string
   actionInputs: Array<ActionInput>
   newConfig: SphinxConfig
   executionMode: ExecutionMode
@@ -104,6 +105,7 @@ export type DeploymentInfo = {
   nonce: string
   chainId: string
   blockGasLimit: string
+  blockNumber: string
   safeInitData: string
   newConfig: SphinxConfig
   executionMode: ExecutionMode

--- a/packages/core/test/preview.spec.ts
+++ b/packages/core/test/preview.spec.ts
@@ -113,6 +113,7 @@ const originalParsedConfig: ParsedConfig = {
   nonce: '0',
   arbitraryChain: false,
   blockGasLimit: '0',
+  blockNumber: '0',
   newConfig: {
     mainnets: [],
     projectName: '',

--- a/packages/plugins/src/foundry/decode.ts
+++ b/packages/plugins/src/foundry/decode.ts
@@ -62,6 +62,7 @@ export const decodeDeploymentInfo = (
   } = parsed
 
   const blockGasLimit = abiDecodeUint256(parsed.blockGasLimit)
+  const blockNumber = abiDecodeUint256(parsed.blockNumber)
   const chainId = abiDecodeUint256(parsed.chainId)
   const executionMode = abiDecodeUint256(parsed.executionMode)
   const nonce = abiDecodeUint256(parsed.nonce)
@@ -91,6 +92,7 @@ export const decodeDeploymentInfo = (
     nonce,
     chainId,
     blockGasLimit,
+    blockNumber,
     initialState: {
       ...initialState,
     },
@@ -131,6 +133,7 @@ export const makeParsedConfig = (
     nonce,
     chainId,
     blockGasLimit,
+    blockNumber,
     newConfig,
     executionMode,
     initialState,
@@ -298,6 +301,7 @@ export const makeParsedConfig = (
     nonce,
     chainId,
     blockGasLimit,
+    blockNumber,
     newConfig,
     executionMode,
     initialState,

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -405,6 +405,7 @@ export const makeDeployment = async (
         nonce: merkleRootNonce.toString(),
         chainId: chainId.toString(),
         blockGasLimit: block.gasLimit.toString(),
+        blockNumber: block.number.toString(),
         initialState: {
           isSafeDeployed: (await provider.getCode(safeAddress)) !== '0x',
           isModuleDeployed: (await provider.getCode(moduleAddress)) !== '0x',

--- a/packages/plugins/test/mocha/mock.ts
+++ b/packages/plugins/test/mocha/mock.ts
@@ -130,6 +130,7 @@ const makeMockParsedConfig = (): ParsedConfig => {
     nonce: '0',
     chainId: '1',
     blockGasLimit: '0',
+    blockNumber: '0',
     actionInputs: [
       {
         contracts: [],


### PR DESCRIPTION
Previously, our simulation was always using the latest block, which was potentially causing it to be flaky. This PR attempts to make the simulation more reliable by using a less recent block number. Specifically, we use the same block number in the simulation and the collection phase.

An alternative approach is to use a block number that's a certain number of blocks behind the latest block number. I think it's an acceptable alternative, but less than ideal for a couple reasons:
1. Different networks have vastly different block times, so it may be tricky to choose a single number of blocks to rewind. E.g. Rootstock's block time is 33s whereas Arbitrum's seems to be multiple blocks per second.
2. Rewinding a certain number of blocks is prone to the following edge case, which is admittedly contrived:
  a. User executes a transaction on the live network
  b. User calls the Deploy or Propose command. The user's script relies on the transaction in the previous step.
  c. The collection phase succeeds because it uses the latest block number, but the simulation fails because it uses an older block number.

**Note**: This PR adds an additional field to the `ParsedConfig` (the `blockNumber`) which is potentially a breaking change. I checked that this shouldn't break the `verifySphinxConfig`, `executeDeployment`, and `buildDeploymentWithCompilerConfigs` functions. I could've implemented this without adding a field to the `ParsedConfig`, but it would've introduced complexity, which didn't seem worth it given that we're simply adding a new field to the `ParsedConfig`.

This PR should hopefully improve the reliability of the simulation, but I think we should implement retries to make it really reliable. ([Relevant ticket](https://linear.app/chugsplash/issue/CHU-447/implement-better-timeout-and-retry-logic-in-execution-logic))