### PR TITLE
fix(core): use `getBytesLength` to support bytecode that has library placeholders

### DIFF
--- a/.changeset/funny-pans-do.md
+++ b/.changeset/funny-pans-do.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Use `getBytesLength` to support bytecode that has library placeholders

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -21,6 +21,7 @@ import { SphinxJsonRpcProvider } from './provider'
 import { CompilerConfig, ConfigArtifacts } from './config/types'
 import {
   fetchSphinxManagedBaseUrl,
+  getBytesLength,
   getNetworkNameDirectory,
   isSphinxTransaction,
   toSphinxTransaction,
@@ -348,7 +349,7 @@ const makeContractDeploymentArtifacts = async (
       // or immutable variable placeholders, which are always the same length as the real values.
       const encodedConstructorArgs = ethers.dataSlice(
         initCodeWithArgs,
-        ethers.dataLength(bytecode)
+        getBytesLength(bytecode)
       )
 
       const constructorFragment = iface.fragments.find(

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -21,6 +21,7 @@ import { SphinxJsonRpcProvider } from './provider'
 import { getMinimumCompilerInput } from './languages/solidity/compiler'
 import {
   formatSolcLongVersion,
+  getBytesLength,
   getNetworkNameForChainId,
   isLiveNetwork,
   sleep,
@@ -80,7 +81,7 @@ export const verifySphinxConfig = async (
       // real values.
       const encodedConstructorArgs = ethers.dataSlice(
         initCodeWithArgs,
-        ethers.dataLength(artifact.bytecode)
+        getBytesLength(artifact.bytecode)
       )
 
       const result = await attemptVerification(
@@ -136,7 +137,7 @@ export const verifyDeploymentWithRetries = async (
         // real values.
         const encodedConstructorArgs = ethers.dataSlice(
           initCodeWithArgs,
-          ethers.dataLength(artifact.bytecode)
+          getBytesLength(artifact.bytecode)
         )
 
         const result = await attemptVerification(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1526,7 +1526,7 @@ export const getAbiEncodedConstructorArgs = (
   initCodeWithArgs: string,
   artifactBytecode: string
 ): string => {
-  return ethers.dataSlice(initCodeWithArgs, ethers.dataLength(artifactBytecode))
+  return ethers.dataSlice(initCodeWithArgs, getBytesLength(artifactBytecode))
 }
 
 /**


### PR DESCRIPTION
An error is thrown when calling `ethers.dataLength` on bytecode that contains a library placeholder. There are a few places in our codebase where we used this function. This PR replaces all occurrences with our `getBytesLength` function, which doesn't error.