### PR TITLE
fix(pg): Optimize BuildInfo storage in DeploymentConfig

### DIFF
--- a/packages/core/src/actions/execute.ts
+++ b/packages/core/src/actions/execute.ts
@@ -1157,8 +1157,6 @@ export const compileAndExecuteDeployment = async (
     return
   }
 
-  const { projectName } = targetNetworkNetworkConfig.newConfig
-
   // get active deployment ID for this project
   const moduleAddress = deployment.moduleAddress
   const sphinxModuleReadOnly = new ethers.Contract(
@@ -1190,10 +1188,6 @@ export const compileAndExecuteDeployment = async (
   deploymentContext.spinner?.start('Execution ready')
 
   if (deployment.status === 'approved') {
-    logger?.info(
-      `[Executor ${networkName}]: compiled ${projectName} on: ${networkName}.`
-    )
-
     let receipts: ethers.TransactionReceipt[] = []
     let batches: SphinxLeafWithProof[][] = []
     let finalStatus: bigint

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -276,6 +276,7 @@ export const convertEthersTransactionReceipt = (
 const makeContractDeploymentArtifacts = async (
   merkleRoot: string,
   networkConfig: NetworkConfig,
+  deploymentConfig: DeploymentConfig,
   receipts: Array<SphinxTransactionReceipt>,
   configArtifacts: ConfigArtifacts,
   previousArtifacts: {
@@ -301,8 +302,9 @@ const makeContractDeploymentArtifacts = async (
   for (const action of networkConfig.actionInputs) {
     for (const contract of action.contracts) {
       const { fullyQualifiedName, initCodeWithArgs, address } = contract
-      const { artifact: compilerArtifact, buildInfo } =
+      const { artifact: compilerArtifact, buildInfoId } =
         configArtifacts[fullyQualifiedName]
+      const buildInfo = deploymentConfig.buildInfos[buildInfoId]
 
       if (!compilerArtifact || !buildInfo) {
         throw new Error(`Could not find artifact for: ${fullyQualifiedName}`)
@@ -569,6 +571,7 @@ export const makeDeploymentArtifacts = async (
     const contractArtifacts = await makeContractDeploymentArtifacts(
       merkleRoot,
       networkConfig,
+      deploymentConfig,
       receipts,
       configArtifacts,
       previousContractArtifacts,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -194,6 +194,10 @@ interface AbstractActionInput extends SphinxTransaction {
   index: string
 }
 
+export interface BuildInfos {
+  [id: string]: BuildInfo
+}
+
 /**
  * Config object with added compilation details. Must add compilation details to the config before
  * the config can be published or off-chain tooling won't be able to re-generate the deployment.
@@ -202,20 +206,14 @@ export interface DeploymentConfig {
   networkConfigs: Array<NetworkConfig>
   merkleTree: SphinxMerkleTree
   configArtifacts: ConfigArtifacts
+  buildInfos: BuildInfos
   inputs: Array<CompilerInput>
   version: string
 }
 
 export type ConfigArtifacts = {
   [fullyQualifiedName: string]: {
-    buildInfo: BuildInfo
-    artifact: ContractArtifact
-  }
-}
-
-export type ConfigArtifactsRemote = {
-  [fullyQualifiedName: string]: {
-    buildInfo: BuildInfo
+    buildInfoId: string
     artifact: ContractArtifact
   }
 }
@@ -239,7 +237,7 @@ export type FoundryContractConfig = {
 
 export type GetConfigArtifacts = (
   initCodeWithArgsArray: Array<string>
-) => Promise<ConfigArtifacts>
+) => Promise<{ configArtifacts: ConfigArtifacts; buildInfos: BuildInfos }>
 
 export type GetProviderForChainId = (chainId: number) => SphinxJsonRpcProvider
 

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@sphinx-labs/contracts'
 
 import {
+  BuildInfos,
   ConfigArtifacts,
   DeploymentConfig,
   NetworkConfig,
@@ -19,6 +20,7 @@ dotenv.config()
 export const makeDeploymentConfig = (
   networkConfigs: Array<NetworkConfig>,
   configArtifacts: ConfigArtifacts,
+  buildInfos: BuildInfos,
   merkleTree: SphinxMerkleTree
 ): DeploymentConfig => {
   const sphinxInputs: Array<CompilerInput> = []
@@ -26,8 +28,9 @@ export const makeDeploymentConfig = (
   for (const networkConfig of networkConfigs) {
     for (const actionInput of networkConfig.actionInputs) {
       for (const { fullyQualifiedName } of actionInput.contracts) {
-        const { buildInfo, artifact } = configArtifacts[fullyQualifiedName]
-        if (!buildInfo || !artifact) {
+        const { buildInfoId, artifact } = configArtifacts[fullyQualifiedName]
+        const buildInfo = buildInfos[buildInfoId]
+        if (!buildInfos[buildInfoId] || !artifact) {
           throw new Error(`Could not find artifact for: ${fullyQualifiedName}`)
         }
 
@@ -67,6 +70,7 @@ export const makeDeploymentConfig = (
 
   return {
     networkConfigs,
+    buildInfos,
     inputs: sphinxInputs,
     version: COMPILER_CONFIG_VERSION,
     merkleTree,

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -265,7 +265,9 @@ export const deploy = async (
   const initCodeWithArgsArray = getInitCodeWithArgsArray(
     deploymentInfo.accountAccesses
   )
-  const configArtifacts = await getConfigArtifacts(initCodeWithArgsArray)
+  const { configArtifacts, buildInfos } = await getConfigArtifacts(
+    initCodeWithArgsArray
+  )
 
   await assertNoLinkedLibraries(
     scriptPath,
@@ -295,6 +297,7 @@ export const deploy = async (
   const deploymentConfig = makeDeploymentConfig(
     [networkConfig],
     configArtifacts,
+    buildInfos,
     merkleTree
   )
 
@@ -437,8 +440,7 @@ export const deploy = async (
     const etherscanApiKey = etherscan[network].key
 
     await verifyDeploymentWithRetries(
-      networkConfig,
-      configArtifacts,
+      deploymentConfig,
       provider,
       etherscanApiKey
     )

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -20,6 +20,7 @@ import ora from 'ora'
 import { blue, red } from 'chalk'
 import { ethers } from 'ethers'
 import {
+  BuildInfos,
   ConfigArtifacts,
   DeploymentInfo,
   GetConfigArtifacts,
@@ -72,6 +73,7 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
 ): Promise<{
   networkConfigArray?: Array<NetworkConfig>
   configArtifacts?: ConfigArtifacts
+  buildInfos?: BuildInfos
   isEmpty: boolean
 }> => {
   const { testnets, mainnets } = await getSphinxConfigFromScript(
@@ -169,7 +171,9 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
     collected.flatMap(({ deploymentInfo }) => deploymentInfo.accountAccesses)
   )
 
-  const configArtifacts = await getConfigArtifacts(initCodeWithArgsArray)
+  const { configArtifacts, buildInfos } = await getConfigArtifacts(
+    initCodeWithArgsArray
+  )
 
   await assertNoLinkedLibraries(
     scriptPath,
@@ -202,6 +206,7 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
   return {
     networkConfigArray,
     configArtifacts,
+    buildInfos,
     isEmpty: false,
   }
 }
@@ -270,7 +275,7 @@ export const propose = async (
     foundryToml.cachePath
   )
 
-  const { networkConfigArray, configArtifacts, isEmpty } =
+  const { networkConfigArray, configArtifacts, isEmpty, buildInfos } =
     await sphinxContext.buildNetworkConfigArray(
       scriptPath,
       isTestnet,
@@ -290,9 +295,9 @@ export const propose = async (
   }
 
   // Narrow the TypeScript type of the NetworkConfig and ConfigArtifacts.
-  if (!networkConfigArray || !configArtifacts) {
+  if (!networkConfigArray || !configArtifacts || !buildInfos) {
     throw new Error(
-      `NetworkConfig or ConfigArtifacts not defined. Should never happen.`
+      `NetworkConfig, ConfigArtifacts, or BuildInfos not defined. Should never happen.`
     )
   }
 
@@ -305,6 +310,7 @@ export const propose = async (
   const deploymentConfig = makeDeploymentConfig(
     networkConfigArray,
     configArtifacts,
+    buildInfos,
     merkleTree
   )
 

--- a/packages/plugins/src/cli/types.ts
+++ b/packages/plugins/src/cli/types.ts
@@ -5,6 +5,7 @@ import {
   ConfigArtifacts,
   GetConfigArtifacts,
   NetworkConfig,
+  BuildInfos,
 } from '@sphinx-labs/core'
 
 import { FoundryToml } from '../foundry/types'
@@ -61,6 +62,7 @@ export type BuildNetworkConfigArray = (
 ) => Promise<{
   networkConfigArray?: Array<NetworkConfig>
   configArtifacts?: ConfigArtifacts
+  buildInfos?: BuildInfos
   isEmpty: boolean
 }>
 

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -43,6 +43,7 @@ import {
   ParsedVariable,
   SphinxConfig,
   SphinxConfigWithAddresses,
+  BuildInfos,
 } from '@sphinx-labs/core/dist/config/types'
 import { parse } from 'semver'
 import chain from 'stream-chain'
@@ -562,6 +563,7 @@ export const makeGetConfigArtifacts = (
     )
 
     const configArtifacts: ConfigArtifacts = {}
+    const buildInfos: BuildInfos = {}
 
     for (const {
       fullyQualifiedName,
@@ -572,13 +574,15 @@ export const makeGetConfigArtifacts = (
         buildInfo.solcLongVersion
       )
 
+      buildInfos[buildInfo.id] = buildInfo
+
       configArtifacts[fullyQualifiedName] = {
         artifact,
-        buildInfo,
+        buildInfoId: buildInfo.id,
       }
     }
 
-    return configArtifacts
+    return { configArtifacts, buildInfos }
   }
 }
 

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -454,7 +454,9 @@ export const makeDeployment = async (
     )
   )
 
-  const configArtifacts = await getConfigArtifacts(initCodeWithArgsArray)
+  const { configArtifacts, buildInfos } = await getConfigArtifacts(
+    initCodeWithArgsArray
+  )
 
   const networkConfigArray = deploymentInfoArray.map((deploymentInfo) => {
     return makeNetworkConfig(
@@ -471,6 +473,7 @@ export const makeDeployment = async (
   const deploymentConfig = makeDeploymentConfig(
     networkConfigArray,
     configArtifacts,
+    buildInfos,
     merkleTree
   )
 

--- a/packages/plugins/test/mocha/foundry/decode.spec.ts
+++ b/packages/plugins/test/mocha/foundry/decode.spec.ts
@@ -26,11 +26,11 @@ describe('Decoded Actions', () => {
   const mockConfigArtifacts: ConfigArtifacts = {
     [myContract1FullyQualifiedName]: {
       artifact: MyContract1Artifact,
-      buildInfo: {} as any, // Unused
+      buildInfoId: '', // Unused
     },
     [myContract2FullyQualifiedName]: {
       artifact: MyContract2Artifact,
-      buildInfo: {} as any, // Unused
+      buildInfoId: '', // Unused
     },
   }
 

--- a/packages/plugins/test/mocha/foundry/utils.spec.ts
+++ b/packages/plugins/test/mocha/foundry/utils.spec.ts
@@ -605,7 +605,10 @@ describe('Utils', async () => {
       const artifacts = await getConfigArtifacts([
         '0x67363d3d37363d34f03d5260086018f3', // `CREATE3` proxy initcode
       ])
-      expect(artifacts).deep.equals({})
+      expect(artifacts).deep.equals({
+        buildInfos: {},
+        configArtifacts: {},
+      })
     })
   })
 

--- a/packages/plugins/test/mocha/mock.ts
+++ b/packages/plugins/test/mocha/mock.ts
@@ -1,6 +1,7 @@
 import {
   ActionInputType,
   BuildInfo,
+  BuildInfos,
   ConfigArtifacts,
   ExecutionMode,
   GetConfigArtifacts,
@@ -65,6 +66,7 @@ export const makeMockSphinxContext = (
       _initCodeWithArgsArray: Array<string>
     ) => {
       const configArtifacts: ConfigArtifacts = {}
+      const buildInfos: BuildInfos = {}
       for (const name of mockedFullyQualifiedNames) {
         const artifact = await readContractArtifact(
           name,
@@ -91,12 +93,16 @@ export const makeMockSphinxContext = (
             contracts: {},
           },
         }
+        buildInfos[buildInfo.id] = buildInfo
         configArtifacts[name] = {
-          buildInfo,
+          buildInfoId: buildInfo.id,
           artifact,
         }
       }
-      return configArtifacts
+      return {
+        configArtifacts,
+        buildInfos,
+      }
     }
   }
 


### PR DESCRIPTION
## Purpose
Optimize the size of the DeploymentConfig by only including each build info object once.