### PR TITLE
fix(pg): init command does not install foundry fork

### DIFF
--- a/.changeset/forty-hounds-yawn.md
+++ b/.changeset/forty-hounds-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Prompt to install Foundry fork during init

--- a/packages/plugins/src/sample-project/index.ts
+++ b/packages/plugins/src/sample-project/index.ts
@@ -128,7 +128,7 @@ export const init = async (
 
   spinner.succeed('Initialized sample Sphinx project.')
 
-  await handleInstall(spinner, false, true)
+  await handleInstall(spinner, false, false)
 
   await handleCommit()
 }


### PR DESCRIPTION
## Purpose
Fixes a bug where the Foundry fork is not installed during the init command.