### PR TITLE
fix(core): Rootstock

### DIFF
--- a/.changeset/few-carpets-change.md
+++ b/.changeset/few-carpets-change.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/core': patch
+---
+
+Improve support for Rootstock

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Test networks:
 - Moonbase Alpha
 - Evmos Testnet
 - Kava Testnet
+- Rootstock Testnet
 
 More networks are on the way! Please reach out to us in our [Discord](https://discord.gg/7Gc3DK33Np) if there are networks you'd like us to add.
 

--- a/packages/contracts/contracts/foundry/SphinxConstants.sol
+++ b/packages/contracts/contracts/foundry/SphinxConstants.sol
@@ -14,7 +14,7 @@ contract SphinxConstants {
   address public constant safeSingletonAddress = 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552;
   address public constant sphinxModuleImplAddress = 0x8f4E4d51B8050B0ff713eff1F88f3dD8b5e8a530;
 
-  uint8 internal constant numSupportedNetworks = 41;
+  uint8 internal constant numSupportedNetworks = 42;
 
   function getNetworkInfoArray() public pure returns (NetworkInfo[] memory) {
     NetworkInfo[] memory all = new NetworkInfo[](numSupportedNetworks);
@@ -241,24 +241,30 @@ contract SphinxConstants {
       networkType: NetworkType.Mainnet
     });
     all[37] = NetworkInfo({
+      network: Network.rootstock_testnet,
+      name: "rootstock_testnet",
+      chainId: 31,
+      networkType: NetworkType.Testnet
+    });
+    all[38] = NetworkInfo({
       network: Network.zora,
       name: "zora",
       chainId: 7777777,
       networkType: NetworkType.Mainnet
     });
-    all[38] = NetworkInfo({
+    all[39] = NetworkInfo({
       network: Network.zora_sepolia,
       name: "zora_sepolia",
       chainId: 999999999,
       networkType: NetworkType.Testnet
     });
-    all[39] = NetworkInfo({
+    all[40] = NetworkInfo({
       network: Network.rari,
       name: "rari",
       chainId: 1380012617,
       networkType: NetworkType.Mainnet
     });
-    all[40] = NetworkInfo({
+    all[41] = NetworkInfo({
       network: Network.rari_sepolia,
       name: "rari_sepolia",
       chainId: 1918988905,
@@ -306,6 +312,7 @@ enum Network {
   scroll,
   scroll_sepolia,
   rootstock,
+  rootstock_testnet,
   zora,
   zora_sepolia,
   rari,

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -18,6 +18,8 @@ export type SupportedNetwork = {
   queryFilterBlockLimit: number
   legacyTx: boolean
   actionGasLimitBuffer: boolean
+  useHigherMaxGasLimit: boolean
+  eip2028: boolean
   rollupStack?: {
     provider: RollupProvider
     type: RollupType
@@ -30,6 +32,8 @@ export type SupportedLocalNetwork = {
   networkType: NetworkType
   legacyTx: false
   actionGasLimitBuffer: false
+  useHigherMaxGasLimit: false
+  eip2028: true
 }
 
 export const SPHINX_LOCAL_NETWORKS: Array<SupportedLocalNetwork> = [
@@ -39,6 +43,8 @@ export const SPHINX_LOCAL_NETWORKS: Array<SupportedLocalNetwork> = [
     networkType: 'Local',
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
 ]
 
@@ -69,6 +75,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'sepolia',
@@ -91,6 +99,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'optimism',
@@ -113,6 +123,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'optimism_sepolia',
@@ -135,6 +147,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'arbitrum',
@@ -157,6 +171,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'arbitrum_sepolia',
@@ -179,6 +195,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'polygon',
@@ -201,6 +219,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'polygon_mumbai',
@@ -223,6 +243,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'bnb',
@@ -244,6 +266,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'bnb_testnet',
@@ -265,6 +289,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'gnosis',
@@ -286,6 +312,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'gnosis_chiado',
@@ -307,6 +335,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'linea',
@@ -329,6 +359,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'linea_goerli',
@@ -351,6 +383,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'polygon_zkevm',
@@ -372,6 +406,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'polygon_zkevm_goerli',
@@ -393,6 +429,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'avalanche',
@@ -415,6 +453,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'avalanche_fuji',
@@ -437,6 +477,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'fantom',
@@ -458,6 +500,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'fantom_testnet',
@@ -479,6 +523,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'base',
@@ -501,6 +547,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'base_sepolia',
@@ -523,6 +571,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'celo',
@@ -545,6 +595,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'celo_alfajores',
@@ -567,6 +619,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'moonriver',
@@ -588,6 +642,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'moonbeam',
@@ -609,6 +665,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'moonbase_alpha',
@@ -630,6 +688,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'fuse',
@@ -651,6 +711,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'evmos',
@@ -673,6 +735,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'evmos_testnet',
@@ -695,6 +759,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'kava',
@@ -716,6 +782,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'kava_testnet',
@@ -739,6 +807,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 18,
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'oktc',
@@ -760,6 +830,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: true,
     decimals: 18,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
   },
   {
     name: 'scroll',
@@ -781,6 +853,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: true,
+    eip2028: true,
   },
   {
     name: 'scroll_sepolia',
@@ -802,6 +876,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: true,
+    eip2028: true,
   },
   {
     name: 'rootstock',
@@ -823,6 +899,31 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     decimals: 8,
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: true,
+    useHigherMaxGasLimit: true,
+    eip2028: false,
+  },
+  {
+    name: 'rootstock_testnet',
+    displayName: 'Rootstock Testnet',
+    chainId: BigInt(31),
+    rpcUrl: () => process.env.ROOTSTOCK_TESTNET_RPC_URL!,
+    etherscan: {
+      apiURL: 'https://rootstock-testnet.blockscout.com/api',
+      browserURL: 'https://rootstock-testnet.blockscout.com/',
+      envKey: 'ROOTSTOCK_ETHERSCAN_API_KEY',
+      blockExplorer: 'Blockscout',
+    },
+    currency: 'RBTC',
+    dripSize: '0.001',
+    requiredEnvVariables: ['ROOTSTOCK_TESTNET_RPC_URL'],
+    dripVersion: 2,
+    networkType: 'Testnet',
+    legacyTx: true,
+    decimals: 8,
+    queryFilterBlockLimit: 2000,
+    actionGasLimitBuffer: true,
+    useHigherMaxGasLimit: true,
+    eip2028: false,
   },
   {
     name: 'zora',
@@ -843,6 +944,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
     requiredEnvVariables: ['ZORA_RPC_URL'],
     rollupStack: {
       provider: 'Conduit',
@@ -868,6 +971,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
     requiredEnvVariables: ['ZORA_SEPOLIA_RPC_URL'],
     rollupStack: {
       provider: 'Conduit',
@@ -893,6 +998,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
     requiredEnvVariables: ['RARI_RPC_URL'],
     rollupStack: {
       provider: 'Caldera',
@@ -918,6 +1025,8 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     legacyTx: false,
     actionGasLimitBuffer: false,
+    useHigherMaxGasLimit: false,
+    eip2028: true,
     requiredEnvVariables: ['RARI_SEPOLIA_RPC_URL'],
     rollupStack: {
       provider: 'Caldera',

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -151,7 +151,8 @@ export type ProjectDeployment = {
 
 export type EstimateGas = (
   moduleAddress: string,
-  batch: Array<SphinxLeafWithProof>
+  batch: Array<SphinxLeafWithProof>,
+  chainId: bigint
 ) => number
 
 export type ExecuteActions = (

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -195,6 +195,30 @@ export const shouldBufferExecuteActionsGasLimit = (chainId: bigint) => {
   }
 }
 
+export const implementsEIP2028 = (chainId: bigint) => {
+  const network = [...SPHINX_NETWORKS, ...SPHINX_LOCAL_NETWORKS].find(
+    (n) => n.chainId === chainId
+  )
+
+  if (network) {
+    return network.eip2028 ?? true
+  } else {
+    throw new Error(`Unsupported network id ${chainId}`)
+  }
+}
+
+export const shouldUseHigherMaxGasLimit = (chainId: bigint) => {
+  const network = [...SPHINX_NETWORKS, ...SPHINX_LOCAL_NETWORKS].find(
+    (n) => n.chainId === chainId
+  )
+
+  if (network) {
+    return network.useHigherMaxGasLimit ?? false
+  } else {
+    throw new Error(`Unsupported network id ${chainId}`)
+  }
+}
+
 /**
  * The number of blocks that Hardhat rewinds when forking the given network. Rewinding the block
  * number protects against chain reorgs. Copied from Hardhat:

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -57,6 +57,7 @@ import {
   COMPILER_CONFIG_VERSION,
   LocalNetworkMetadata,
   fetchNameForNetwork,
+  shouldUseHigherMaxGasLimit,
 } from './networks'
 import { RelayProposal, StoreDeploymentConfig } from './types'
 
@@ -1334,7 +1335,7 @@ export const getMaxGasLimit = (
   // a lower max gas limit could cause large contract deployments to be unexecutable. Transactions
   // that use ~8.5M gas were executed quickly on Scroll Sepolia, so an 80% limit shouldn't
   // meaningfully impact execution speed.
-  if (chainId === BigInt(534351) || chainId === BigInt(534352)) {
+  if (shouldUseHigherMaxGasLimit(chainId)) {
     return (blockGasLimit * BigInt(8)) / BigInt(10)
   }
 

--- a/packages/core/test/convert.spec.ts
+++ b/packages/core/test/convert.spec.ts
@@ -74,6 +74,7 @@ describe('Convert EthersJS Objects', () => {
     534351:
       '0x0f5e4aeae66a13cde040d9c4603c5e57be8731907755bfcee519b9eb3716158d',
     30: '0x48e3c765b4d066c06e92706d5b91f8daa7f8182a58cba52d8a52bdb5a43fc5dd',
+    31: '0xdb0400ba3f56f653cab12b521d2bf0a61098865c7aeecd39d42711514feaacfa',
   }
 
   before(async () => {

--- a/packages/plugins/src/cli/utils.ts
+++ b/packages/plugins/src/cli/utils.ts
@@ -1,3 +1,5 @@
+import semver from 'semver'
+
 export const BothNetworksSpecifiedError = `You must specify either 'testnets' or 'mainnets', but not both.`
 
 export const ConfirmAndDryRunError =
@@ -26,4 +28,16 @@ export const coerceNetworks = (
 
   // If none of the above conditions are met, throw a general error.
   throw new Error(getInvalidNetworksArgumentError(arg))
+}
+
+export const assertValidNodeVersion = () => {
+  const requiredVersion = '16.16.0'
+  const currentVersion = process.version
+
+  // Compares if the current version is >= requiredVersion
+  if (!semver.gte(currentVersion, requiredVersion)) {
+    throw new Error(
+      `Current Node.js version ${currentVersion} is not sufficient. Sphinx requires >=${requiredVersion}`
+    )
+  }
 }

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -82,6 +82,7 @@ import {
 import { simulate } from '../../hardhat/simulate'
 import { GetNetworkGasEstimate } from '../../cli/types'
 import { BuildInfoTemplate, trimObjectToType } from './trim'
+import { assertValidNodeVersion } from '../../cli/utils'
 
 const readFileAsync = promisify(readFile)
 
@@ -1343,6 +1344,9 @@ export const assertValidVersions = async (
   scriptPath: string,
   targetContract?: string
 ): Promise<void> => {
+  // Validate that the user has a compatible NodeJS version installed
+  assertValidNodeVersion()
+
   // Validate the user's Sphinx dependencies. Specifically, we retrieve the Sphinx contracts library
   // version and empirically check that our Foundry fork is functioning properly.
   const output = await callForgeScriptFunction<{


### PR DESCRIPTION
## Purpose
- Properly calculates the gas cost in our heuristic using the call data cost of 68 per non-zero byte on Rootstock since they do not implement EIP-2028
- Standardizes the way we handle using the 80% block gas limit on Rootstock and Scroll and uses a boolean in the SPHINX_NETWORKS array to implement that
- Moves the buffer we add on the gas limit for action execution on Rootstock out of the `executeActionsViaManagedService` function and into the relayer service
- Adds support for Rootstock testnet.  I'm ok with supporting this and was able to find a functional node provider for it. I would prefer people to run into issues with the gas limit on a testnet rather than mainnet
- I also added a minor unrelated thing to this PR: A check that the user has a compatible NodeJS version installed. I've ran into this issue a few times (because I have Node 14 as my default globally). The current error the user encounters if they do not use at least `16.16.0` is functionally impossible to debug.

I've created [another ticket](https://linear.app/chugsplash/issue/CHU-580/support-max-size-limit-contracts-on-rootstock) to handle increasing the max batch size and/or reducing the buffers we add to our estimates to maximize the size of contract that is deployable on Rootstock using our system. I think we should come back to that if people run into issues using our system on Rootstock, or if Rootstock finishes with implementing EIP-2028.