### PR TITLE
feat(pg): Add timeout and retry logic to simulation

### DIFF
--- a/.changeset/eight-dolls-call.md
+++ b/.changeset/eight-dolls-call.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Add timeout and retry logic to simulation

--- a/packages/plugins/src/hardhat/hardhatRunner.ts
+++ b/packages/plugins/src/hardhat/hardhatRunner.ts
@@ -25,15 +25,10 @@ process.stdin.on('end', async () => {
 const runHardhatSimulation = async (
   taskArgs: simulateDeploymentSubtaskArgs
 ): Promise<void> => {
-  const {
-    receipts,
-    batches,
-  }: Awaited<ReturnType<typeof simulateDeploymentSubtask>> = await hre.run(
-    'sphinxSimulateDeployment',
-    taskArgs
-  )
+  const { receipts }: Awaited<ReturnType<typeof simulateDeploymentSubtask>> =
+    await hre.run('sphinxSimulateDeployment', taskArgs)
 
-  process.stdout.write(JSON.stringify({ receipts, batches }))
+  process.stdout.write(JSON.stringify({ receipts }))
 }
 
 // If an error occurs, we write the error message and stack trace to `stdout` then exit the process
@@ -42,6 +37,22 @@ const runHardhatSimulation = async (
 // actual error message in `stderr`. By using `stdout`, we can throw an error that doesn't contain
 // warnings in the parent process.
 process.on('uncaughtException', (error) => {
+  /**
+   * This catches a common error where the DNS lookup for an rpc url fails. For some reason, this
+   * error is not caught by ethers and is also not caught by our try/catch. So instead we catch it
+   * specifically here and just silently handle it.
+   *
+   * It is safe to silently handle this because the user definitely has a valid RPC url if the process
+   * made it to the simulation at all. So we can reasonably expect that if we handle this and then the
+   * simulation retries, it will succeed.
+   *
+   * It's worth mentioning, that we've already had logic that handles this running in the website backend
+   * and it very reliably works for handling this exact issue.
+   */
+  if (error.message.includes('getaddrinfo ENOTFOUND')) {
+    return
+  }
+
   process.stdout.write(
     JSON.stringify({ message: error.message, stack: error.stack })
   )


### PR DESCRIPTION
## Purpose
Adds timeout and retry logic to the simulation mainly for the purpose of making proposals more reliable.

Note that I chose not to implement retries in the deploy CLI command as part of this PR because that is actually a pretty separate task, would have caused this to take much longer, and generally wasn't the reason we decided to prioritize this. 

I've created a [new ticket](https://linear.app/chugsplash/issue/CHU-583/add-logic-to-relayer-service-to-handle-retrying-with-a-higher-gas) specifically to cover implementing retries in the deploy CLI task.