### PR TITLE
fix(core): use `getBytesLength` to support bytecode that has library placeholders

### DIFF
--- a/.changeset/funny-pans-do.md
+++ b/.changeset/funny-pans-do.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Use `getBytesLength` to support bytecode that has library placeholders

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -26,6 +26,7 @@ import {
 import {
   fetchNetworkConfigFromDeploymentConfig,
   fetchSphinxManagedBaseUrl,
+  getBytesLength,
   getNetworkNameDirectory,
   isSphinxTransaction,
   toSphinxTransaction,
@@ -353,7 +354,7 @@ const makeContractDeploymentArtifacts = async (
       // or immutable variable placeholders, which are always the same length as the real values.
       const encodedConstructorArgs = ethers.dataSlice(
         initCodeWithArgs,
-        ethers.dataLength(bytecode)
+        getBytesLength(bytecode)
       )
 
       const constructorFragment = iface.fragments.find(

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -21,6 +21,7 @@ import { getMinimumCompilerInput } from './languages/solidity/compiler'
 import {
   fetchNetworkConfigFromDeploymentConfig,
   formatSolcLongVersion,
+  getBytesLength,
   isLiveNetwork,
   sleep,
 } from './utils'
@@ -87,7 +88,7 @@ export const verifySphinxConfig = async (
       // real values.
       const encodedConstructorArgs = ethers.dataSlice(
         initCodeWithArgs,
-        ethers.dataLength(artifact.bytecode)
+        getBytesLength(artifact.bytecode)
       )
 
       const result = await attemptVerification(
@@ -148,7 +149,7 @@ export const verifyDeploymentWithRetries = async (
         // real values.
         const encodedConstructorArgs = ethers.dataSlice(
           initCodeWithArgs,
-          ethers.dataLength(artifact.bytecode)
+          getBytesLength(artifact.bytecode)
         )
 
         const result = await attemptVerification(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1428,7 +1428,7 @@ export const getAbiEncodedConstructorArgs = (
   initCodeWithArgs: string,
   artifactBytecode: string
 ): string => {
-  return ethers.dataSlice(initCodeWithArgs, ethers.dataLength(artifactBytecode))
+  return ethers.dataSlice(initCodeWithArgs, getBytesLength(artifactBytecode))
 }
 
 /**


### PR DESCRIPTION
Replaces all instances of `ethers.dataLength` with our own `getBytesLength` function. Copying the JSDoc of our `getBytesLength` function for context:

```
/**
 * Returns the length in bytes of the input hex string.
 *
 * The difference between this function and `ethers.dataLength` is that this function does not throw
 * an error if the input hex string contains library placeholders. This function will return the
 * correct length for hex strings with library placeholders because the placeholders are the same
 * length as library addresses. For more info on library placeholders, see:
 * https://docs.soliditylang.org/en/v0.8.23/using-the-compiler.html#library-linking
 *
 * @example
 * // returns 3
 * getBytesLength("0x123456")
 */
```