### PR TITLE
feat(ci): Force bump plugins package if bumping core or contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
             - packages/demo/node_modules
             - packages/plugins/node_modules
       - run:
+          name: Check valid changesets
+          command: yarn changeset:check:valid
+      - run:
           name: Build monorepo
           command: yarn build
       - save_cache:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "clean": "yarn workspaces run clean",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
-    "changeset:version:custom": "yarn changeset version && yarn workspace @sphinx-labs/contracts run write-version"
+    "changeset:version:custom": "yarn changeset version && yarn workspace @sphinx-labs/contracts run write-version",
+    "changeset:check:valid": "/bin/bash ./scripts/check-valid-changesets.sh"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",

--- a/scripts/check-valid-changesets.sh
+++ b/scripts/check-valid-changesets.sh
@@ -1,0 +1,6 @@
+
+variable=$(yarn changeset status)
+if [[ ($variable == *sphinx-labs/core* || $variable == *sphinx-labs/contracts*) && $variable != *sphinx-labs/plugins* ]]; then
+    echo "Detected changesets for core or contracts, but not plugins. You must always update sphinx-labs/plugins when updating the core or contracts package. "
+    exit 1
+fi


### PR DESCRIPTION
## Purpose
This addresses the following edge case in our release process: 
1. Make some changes to the core or contracts package
2. Create a changeset for the core or contracts package, but *not* the plugins package
3. Make a release updating the core or contracts package

### Result
A release will only be made for core and contracts, not plugins. Additionally, the core and contracts package versions will not be updated in the plugins package. So, if we later go and do a release for the plugins package, it will still list the older core and contract versions as minimum dependencies. 

This is not an issue if the user is doing a fresh installation of the package and the new core/contracts package version is only a patch change b/c the new version will automatically be installed. However, if the user already has our package installed and is just updating the new version, they will not automatically get the new contracts/core version because of the yarn.lock file will cause them to keep the old versions installed. Additionally, the new version won't be installed if the change is minor or major, even if the user is doing a fresh installation.

As a result, users can continue encountering errors we've supposedly fixed because they don't have the latest core or contracts package version, even if they do have the latest plugin package version. 

For context, I'm addressing this because Kevin ran into it in relation to the fix we released for Rootstock. That network didn't work for him until he deleted his yarn.lock file and ran `yarn install` again to fetch the latest packages. 

## Solution
Add a CI check to enforce that if we have a changeset for the core or contracts package, we must also have one for the plugins package. 