### PR TITLE
docs: remove networks in sphinx config in favor of rpc_endpoints

### DIFF
--- a/docs/ci-proposals.md
+++ b/docs/ci-proposals.md
@@ -55,7 +55,7 @@ touch .github/workflows/sphinx.deploy.yml
 
 ## 5. Create the dry run workflow
 
-First, we'll create a workflow that dry-runs the proposal whenever a pull request is opened or updated. The dry run includes a simulation for the deployment, which will throw an error if a transaction reverts. This prevents you from merging pull requests for deployments bound to fail.
+First, we'll create a workflow that dry-runs the proposal on test networks whenever a pull request is opened or updated. The dry run includes a simulation for the deployment, which will throw an error if a transaction reverts. This prevents you from merging pull requests for deployments bound to fail.
 
 Copy and paste the following into your `sphinx.dry-run.yml` file:
 
@@ -83,7 +83,7 @@ jobs:
       - name: Install Sphinx Solidity Library
         run: yarn sphinx install
       - name: Dry Run
-        run: npx sphinx propose <path/to/your/script.s.sol> --dry-run --networks testnets
+        run: npx sphinx propose <path/to/your/script.s.sol> --dry-run --networks <NETWORK_NAMES>
 ```
 
 Here is a list of things you may need to change in the template:
@@ -91,6 +91,7 @@ Here is a list of things you may need to change in the template:
 - If your repository doesn't use Yarn, update the `yarn --frozen-lockfile` step under `jobs`.
 - If your repository uses pnpm instead of Yarn or npm, change `npx sphinx propose` to `pnpm sphinx propose`.
 - In the `sphinx propose` command, replace `<path/to/your/script.s.sol>` with the path to your Forge script.
+- In the `sphinx propose` command, replace `<NETWORK_NAMES>` with the test networks to propose on.
 
 ## 6. Create the proposal workflow
 Next, we'll create a workflow to propose the deployment when a pull request is merged.
@@ -124,7 +125,7 @@ jobs:
       - name: Install Sphinx Solidity Library
         run: yarn sphinx install
       - name: Propose
-        run: npx sphinx propose <path/to/your/script.s.sol> --confirm --networks testnets
+        run: npx sphinx propose <path/to/your/script.s.sol> --confirm --networks <NETWORK_NAMES>
 ```
 
 Here is a list of things you may need to change in the template:
@@ -133,6 +134,7 @@ Here is a list of things you may need to change in the template:
 - If your repository doesn't use Yarn, update the `yarn --frozen-lockfile` step under `jobs`.
 - If your repository uses pnpm instead of Yarn or npm, change `npx sphinx propose` to `pnpm sphinx propose`.
 - In the `sphinx propose` command, replace `<path/to/your/script.s.sol>` with the path to your Forge script.
+- In the `sphinx propose` command, replace `<NETWORK_NAMES>` with the test networks to propose on.
 
 ## 7. Configure secret variables
 
@@ -148,6 +150,6 @@ Push your branch to GitHub, open a PR, and merge it after the dry run succeeds. 
 
 ## 9. Production deployments
 
-In this guide, we've configured the CI process to deploy against test networks. When you're ready to deploy in production, simply update the `sphinx propose` command to include `--networks mainnets` instead of `--networks testnets`. Make sure you update both templates.
+In this guide, we've configured the CI process to deploy against test networks. When you're ready to deploy in production, simply replace the test networks in the `sphinx propose` commands with names of the production networks. Make sure you update both templates.
 
 In practice, we recommend triggering testnet deployments when merging to your development branch, and triggering production deployments when you merge from your development branch to your main branch.

--- a/docs/cli-existing-project.md
+++ b/docs/cli-existing-project.md
@@ -1,6 +1,6 @@
 # Getting Started with an Existing Foundry Project
 
-In this guide, you'll integrate Sphinx with your existing Foundry project. Then, you'll deploy your project on a few testnets.
+In this guide, you'll integrate Sphinx with your existing Foundry project. Then, you'll deploy your project on test networks.
 
 Deployments are a three-step process with the DevOps Platform:
 
@@ -25,11 +25,10 @@ In this guide, you'll propose the deployment on the command line and then approv
   e. [Handle new sender address](#e-handle-new-sender-address)\
   f. [Add configuration options](#e-add-configuration-options)
 7. [Add environment variables](#7-add-environment-variables)
-8. [Update RPC endpoints](#8-update-rpc-endpoints)
-9. [Update `foundry.toml` settings](#9-update-foundrytoml-settings)
-10. [Run tests](#10-run-tests)
-11. [Propose on testnets](#11-propose-on-testnets)
-12. [Next steps](#12-next-steps)
+8. [Update `foundry.toml` settings](#8-update-foundrytoml-settings)
+9. [Run tests](#9-run-tests)
+10. [Propose on testnets](#10-propose-on-testnets)
+11. [Next steps](#11-next-steps)
 
 ## 1. Prerequisites
 
@@ -158,11 +157,6 @@ Copy and paste the following `configureSphinx()` function template into your scr
 function configureSphinx() public override {
   sphinxConfig.owners = [<your address>];
   sphinxConfig.orgId = <Sphinx org ID>;
-  sphinxConfig.testnets = [
-    Network.sepolia,
-    Network.optimism_sepolia,
-    Network.arbitrum_sepolia
-  ];
   sphinxConfig.projectName = "My_First_Project";
   sphinxConfig.threshold = 1;
 }
@@ -171,7 +165,6 @@ function configureSphinx() public override {
 You'll need to update the following fields in this template:
 * Enter your address in the `owners` array.
 * Enter your Sphinx Organization ID in the `orgId` field. It's a public field, so you don't need to keep it secret. You can find it in the Sphinx UI.
-* If you'd like to deploy on networks other than Sepolia, Optimism Sepolia, and Arbitrum Sepolia, update the `testnets` array. You can find a list of valid fields in the [Sphinx Configuration Options reference](https://github.com/sphinx-labs/sphinx/blob/main/docs/configuration-options.md#network-testnets).
 
 ## 7. Add environment variables
 
@@ -185,20 +178,7 @@ Also, if you haven't added your node provider API key as an environment variable
 ALCHEMY_API_KEY=<your_api_key>
 ```
 
-## 8. Update RPC endpoints
-
-Include an RPC endpoint in your `foundry.toml` for each testnet you'd like to deploy on. The names of the RPC endpoints in your `foundry.toml` must match the testnet names in the `sphinxConfig.testnets` array that you defined in your deployment script. For example, `sepolia` is a valid RPC endpoint name, but `ethereum_testnet` is not.
-
-Here's what your `foundry.toml` might look like if you're using Alchemy:
-
-```toml
-[rpc_endpoints]
-sepolia = "https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-optimism_sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-arbitrum_sepolia = "https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-```
-
-## 9. Update `foundry.toml` settings
+## 8. Update `foundry.toml` settings
 
 Update your `foundry.toml` file to include a few settings required by Sphinx. We recommend putting them in `[profile.default]`.
 
@@ -208,26 +188,26 @@ extra_output = ['storageLayout']
 fs_permissions = [{ access = "read-write", path = "./"}]
 ```
 
-## 10. Run tests
+## 9. Run tests
 
 You've finished integrating Sphinx! Your next step is to check that your existing tests are passing. Go ahead and run your Forge tests.
 
 If you can't get your test suite to pass, we're more than happy to help! Reach out to us in our [Discord](https://discord.gg/7Gc3DK33Np).
 
-## 11. Propose on testnets
+## 10. Propose on testnets
 
-Copy and paste one of the following commands to propose your deployment with the DevOps Platform. Make sure to replace `<path/to/your/Script.s.sol>` with the path to your Forge script.
+Copy and paste one of the following commands to propose your deployment with the DevOps Platform. Make sure to replace `<PATH_TO_FORGE_SCRIPT>` with the path to your Forge script. Also, make sure to replace `<NETWORK_NAMES>` with the testnets you want to deploy on, which must match the network names in the `rpc_endpoints` section of your `foundry.toml`.
 
 Using Yarn or npm:
 
 ```
-npx sphinx propose <path/to/your/Script.s.sol> --networks testnets
+npx sphinx propose <PATH_TO_FORGE_SCRIPT> --networks <NETWORK_NAMES>
 ```
 
 Using pnpm:
 
 ```
-pnpm sphinx propose <path/to/your/Script.s.sol> --networks testnets
+pnpm sphinx propose <PATH_TO_FORGE_SCRIPT> --networks <NETWORK_NAMES>
 ```
 
 Here are the steps that occur when you run this command:
@@ -237,6 +217,6 @@ Here are the steps that occur when you run this command:
 
 When the proposal is finished, go to the [Sphinx UI](https://sphinx.dev) to approve the deployment. After you approve it, you can monitor the deployment's status in the UI while it's executed.
 
-## 12. Next steps
+## 11. Next steps
 
 Before you use Sphinx in production, we recommend reading the [Writing Deployment Scripts with Sphinx guide](https://github.com/sphinx-labs/sphinx/blob/main/docs/writing-scripts.md), which covers essential information for using Sphinx.

--- a/docs/cli-propose.md
+++ b/docs/cli-propose.md
@@ -9,49 +9,59 @@
 - [Examples](#examples)
 
 ## Overview
-The `propose` command proposes a deployment in the Sphinx DevOps Platform.
+The `propose` command proposes a deployment to the Sphinx DevOps Platform.
 
 The following steps occur when this command is run:
 1. **Simulation**: Sphinx simulates the deployment by invoking the script's `run()` function on a fork of each network. If a transaction reverts during the simulation, Sphinx will throw an error.
 2. **Preview**: Sphinx displays the broadcasted transactions in a preview, which the user will be prompted to confirm.
 3. **Relay**: Sphinx submits the deployment to the Sphinx UI, where the user will approve it.
 
+> Note: The `propose` command is only available on networks supported by Sphinx's DevOps Platform. See the list of supported networks in the main [README](https://github.com/sphinx-labs/sphinx/blob/main/README.md#networks-supported-by-the-devops-platform).
+
 ## Usage
 
 Using `npx`:
 
 ```
-npx sphinx propose <SCRIPT_PATH> --networks <testnets|mainnets> [options]
+npx sphinx propose <SCRIPT_PATH> --networks <NETWORK_NAMES...|testnets|mainnets> [options]
 ```
 
 Using `pnpm`:
 
 ```
-pnpm sphinx propose <SCRIPT_PATH> --networks <testnets|mainnets> [options]
+pnpm sphinx propose <SCRIPT_PATH> --networks <NETWORK_NAMES...|testnets|mainnets> [options]
 ```
 
 ### Parameters
 - `<SCRIPT_PATH>`: **Required**. The path to the Forge script file to propose.
 
 ### Options
-- `--networks <testnets|mainnets>`: **Required**. Choose between proposing on the test networks (`sphinxConfig.testnets`) or the production networks (`sphinxConfig.mainnets`) in your script.
+- `--networks <NETWORK_NAMES...|testnets|mainnets>`: **Required**. The network(s) to propose on. Options include:
+  - Arbitrary network names (e.g., `ethereum optimism arbitrum`): Propose on one or more networks, which must match the network names in the `rpc_endpoints` section of your `foundry.toml`.
+  - `testnets`: Propose on the test networks in your `sphinxConfig.testnets` array. Provides a convenient way to propose on many networks without needing to specify them on the command line. Requires additional configuration; see the [Configuration Options section for `sphinxConfig.testnets`](https://github.com/sphinx-labs/sphinx/blob/main/docs/configuration-options.md#string-testnets-optional).
+  - `mainnets`: Propose on the production networks in your `sphinxConfig.mainnets` array. Provides a convenient way to propose on many networks without needing to specify them on the command line. Requires additional configuration; see the [Configuration Options section for `sphinxConfig.mainnets`](https://github.com/sphinx-labs/sphinx/blob/main/docs/configuration-options.md#string-mainnets-optional).
 - `--confirm`: **Optional**. Confirm the proposal without previewing it. Useful for automating proposals.
 - `--dry-run`: **Optional**. Perform a trial run without sending data to Sphinx's backend. Useful for testing and validation.
 - `--silent`: **Optional**. Suppress output to display only error messages. Must be combined with `--confirm` to confirm the proposal without previewing it.
 - `--target-contract <TARGET_CONTRACT>` (Alias: `--tc <TARGET_CONTRACT>`): **Optional**. Specify a contract in multi-contract scripts.
 
 ## Examples
-1. Propose a deployment on testnets using a script located at `./path/to/script.s.sol`:
+1. Propose a script located at `./path/to/script.s.sol` on Sepolia:
    ```bash
-   npx sphinx propose ./path/to/script.s.sol --networks testnets
+   npx sphinx propose ./path/to/script.s.sol --networks sepolia
    ```
 
-2. Dry run a proposal on production networks using a script located at `./path/to/script.s.sol`:
+2. Propose a script located at `./path/to/script.s.sol` on a few production networks:
+   ```bash
+   npx sphinx propose ./path/to/script.s.sol --networks ethereum optimism arbitrum
+   ```
+
+3. Propose a script located at `./path/to/script.s.sol` on all networks in `sphinxConfig.testnets`, skipping the deployment preview:
+   ```bash
+   npx sphinx propose ./path/to/script.s.sol --networks testnets --confirm
+   ```
+
+4. Dry run a proposal on all networks in `sphinxConfig.mainnets` using a script located at `./path/to/script.s.sol`:
    ```bash
    npx sphinx propose ./path/to/script.s.sol --networks mainnets --dry-run
-   ```
-
-3. Propose a script at `./path/to/script.s.sol` on production networks, skipping the deployment preview:
-   ```bash
-   npx sphinx propose ./path/to/script.s.sol --networks mainnets --confirm
    ```

--- a/docs/cli-quickstart.md
+++ b/docs/cli-quickstart.md
@@ -104,13 +104,13 @@ Copy and paste one of the following commands to propose your deployment with the
 Using Yarn or npm:
 
 ```
-npx sphinx propose script/HelloSphinx.s.sol --networks testnets
+npx sphinx propose script/HelloSphinx.s.sol --networks sepolia optimism_sepolia arbitrum_sepolia
 ```
 
 Using pnpm:
 
 ```
-pnpm sphinx propose script/HelloSphinx.s.sol --networks testnets
+pnpm sphinx propose script/HelloSphinx.s.sol --networks sepolia optimism_sepolia arbitrum_sepolia
 ```
 
 Here are the steps that occur when you run this command:

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -12,32 +12,32 @@ function configureSphinx() public override {
 ## Table of Contents
 
 - [Configuration Options](#configuration-options)
-  - [`address[] owners`](#address-owners)
-  - [`uint256 threshold`](#uint256-threshold)
-  - [`string projectName`](#string-projectname)
-  - [`uint256 saltNonce`](#uint256-saltnonce)
+  - [`address[] owners`](#address-owners-required)
+  - [`uint256 threshold`](#uint256-threshold-required)
+  - [`string projectName`](#string-projectname-required)
+  - [`uint256 saltNonce`](#uint256-saltnonce-required)
 - [DevOps Platform Options](#devops-platform-options)
-  - [`string orgId`](#string-orgid)
-  - [`Network[] mainnets`](#network-mainnets)
-  - [`Network[] testnets`](#network-testnets)
+  - [`string orgId`](#string-orgid-required)
+  - [`string[] mainnets`](#string-mainnets-optional)
+  - [`string[] testnets`](#string-testnets-optional)
 
 ## Configuration Options
 
-### `address[] owners`
+### `address[] owners` (Required)
 ```
 sphinxConfig.owners = [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266];
 ```
 
 The list of addresses that own your Gnosis Safe. Owners must approve transactions before they can be executed.
 
-### `uint256 threshold`
+### `uint256 threshold` (Required)
 ```
 sphinxConfig.threshold = 1;
 ```
 
 The number of owners required to approve transactions.
 
-### `string projectName`
+### `string projectName` (Required)
 
 ```
 sphinxConfig.projectName = "My_Project";
@@ -45,13 +45,13 @@ sphinxConfig.projectName = "My_Project";
 
 The name of your project, which is the top-level directory for your [deployment artifacts](https://github.com/sphinx-labs/sphinx/blob/main/docs/deployment-artifacts.md).
 
-### `uint256 saltNonce`
+### `uint256 saltNonce` (Required)
 
 An optional nonce which is one of the inputs that determines the `CREATE2` address of a Gnosis Safe. Changing this to a new value will cause a Gnosis Safe to be deployed at a new address. Defaults to `0`.
 
 ## DevOps Platform Options
 
-### `string orgId`
+### `string orgId` (Required)
 
 ```
 sphinxConfig.orgId = "abcd-1234";
@@ -59,63 +59,18 @@ sphinxConfig.orgId = "abcd-1234";
 
 Your organization ID from the Sphinx UI (under "Options" -> "API Credentials"). This is a public field, so you don't need to keep it secret.
 
-### `Network[] mainnets`
+### `string[] mainnets` (Optional)
 
 ```
-sphinxConfig.mainnets = [Network.ethereum, Network.arbitrum];
+sphinxConfig.mainnets = ["ethereum", "optimism", "arbitrum"];
 ```
 
-The list of production networks to deploy on.
+A list of production networks to propose on via the `--networks mainnets` flag. Provides a convenient way to propose on many networks without needing to specify them on the command line. Note that the strings in this array must match the network names in the `rpc_endpoints` section of your `foundry.toml` file.
 
-Valid values:
+### `string[] testnets` (Optional)
 
-| Network | `Network` enum |
-| ----------- | ----------- |
-| Ethereum | `Network.ethereum` |
-| Optimism | `Network.optimism` |
-| Arbitrum | `Network.arbitrum` |
-| Polygon PoS | `Network.polygon` |
-| Binance Smart Chain | `Network.bnb` |
-| Gnosis Chain | `Network.gnosis` |
-| Linea | `Network.linea` |
-| Polygon zkEVM | `Network.polygon_zkevm` |
-| Avalanche C-Chain | `Network.avalanche` |
-| Fantom | `Network.fantom` |
-| Base | `Network.base` |
-| Scroll | `Network.scroll` |
-| Celo | `Network.celo` |
-| Moonbeam | `Network.moonbeam` |
-| Moonriver | `Network.moonriver` |
-| Fuse | `Network.fuse` |
-| Evmos | `Network.evmos` |
-| Kava | `Network.kava` |
-| OKT Chain | `Network.oktc` |
-| Rootstock | `Network.rootstock` |
-
-### `Network[] testnets`
 ```
-sphinxConfig.testnets = [Network.sepolia, Network.optimism_sepolia];
+sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "arbitrum_sepolia"];
 ```
 
-The list of testnets to deploy on.
-
-Valid values:
-
-| Network | `Network` enum |
-| ----------- | ----------- |
-| Ethereum Sepolia | `Network.sepolia` |
-| Optimism Sepolia | `Network.optimism_sepolia` |
-| Arbitrum Sepolia | `Network.arbitrum_sepolia` |
-| Polygon Mumbai | `Network.polygon_mumbai` |
-| Binance Smart Chain Testnet | `Network.bnb_testnet` |
-| Gnosis Chiado | `Network.gnosis_chiado` |
-| Linea Goerli | `Network.linea_goerli` |
-| Polygon zkEVM Goerli | `Network.polygon_zkevm_goerli` |
-| Avalanche Fuji | `Network.avalanche_fuji` |
-| Fantom Testnet | `Network.fantom_testnet` |
-| Base Sepolia | `Network.base_sepolia` |
-| Scroll | `Network.scroll` |
-| Celo | `Network.celo` |
-| Moonbase Alpha | `Network.moonbase_alpha` |
-| Evmos Testnet | `Network.evmos_testnet` |
-| Kava Testnet | `Network.kava_testnet` |
+A list of test networks to propose on via the `--networks testnets` flag. Provides a convenient way to propose on many networks without needing to specify them on the command line. Note that the strings in this array must match the network names in the `rpc_endpoints` section of your `foundry.toml` file.

--- a/docs/writing-scripts.md
+++ b/docs/writing-scripts.md
@@ -45,8 +45,6 @@ function configureSphinx() public override {
     sphinxConfig.projectName = "My_Project";
 
     // Required settings for the Sphinx DevOps Platform:
-    sphinxConfig.mainnets = [Network.ethereum, Network.optimism];
-    sphinxConfig.testnets = [Network.sepolia, Network.optimism_sepolia];
     sphinxConfig.orgId = "abcd-1234";
 }
 ```


### PR DESCRIPTION
Updates the docs to include arbitrary network names in proposals. Also includes configuration instructions for the `propose --networks [mainnets|testnets]` option. The next couple PRs will implement the new network UX.