### PR TITLE
fix(pg): Handle higher storage cost on Moonbeam

### DIFF
--- a/.changeset/good-fans-relax.md
+++ b/.changeset/good-fans-relax.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Handle higher storage cost on Moonbeam

--- a/packages/contracts/contracts/foundry/Sphinx.sol
+++ b/packages/contracts/contracts/foundry/Sphinx.sol
@@ -21,7 +21,8 @@ import {
     GnosisSafeTransaction,
     ExecutionMode,
     SystemContractInfo,
-    ParsedAccountAccess
+    ParsedAccountAccess,
+    DeployedContractSize
 } from "./SphinxPluginTypes.sol";
 import { SphinxUtils } from "./SphinxUtils.sol";
 import { SphinxConstants } from "./SphinxConstants.sol";
@@ -249,6 +250,11 @@ abstract contract Sphinx {
             accesses,
             safe
         );
+
+        deploymentInfo.encodedDeployedContractSizes = abi.encode(
+            sphinxUtils.fetchDeployedContractSizes(accesses)
+        );
+
         // ABI encode each `ParsedAccountAccess` element individually. If, instead, we ABI encode
         // the entire array as a unit, the encoded bytes will be too large for EthersJS to ABI
         // decode, which causes an error. This occurs for large deployments, i.e. greater than 50

--- a/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
+++ b/packages/contracts/contracts/foundry/SphinxPluginTypes.sol
@@ -75,6 +75,11 @@ struct ParsedAccountAccess {
     Vm.AccountAccess[] nested;
 }
 
+struct DeployedContractSize {
+    address account;
+    uint size;
+}
+
 /**
  * @notice Contains all of the information that's collected in a deployment on a single chain.
  *         The only difference between this struct and the TypeScript `DeploymentInfo` object is
@@ -107,6 +112,7 @@ struct FoundryDeploymentInfo {
     string sphinxLibraryVersion;
     bytes[] encodedAccountAccesses;
     uint256[] gasEstimates;
+    bytes encodedDeployedContractSizes;
 }
 
 enum ExecutionMode {
@@ -250,5 +256,11 @@ contract SphinxPluginTypes {
         external
         view
         returns (SphinxLeafWithProof[][] memory batches)
+    {}
+
+    function deployedContractSizesType()
+        external
+        view
+        returns (DeployedContractSize[] memory deployedContractSizes)
     {}
 }

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -1,3 +1,52 @@
+export enum AccountAccessKind {
+  Call = '0',
+  DelegateCall = '1',
+  CallCode = '2',
+  StaticCall = '3',
+  Create = '4',
+  SelfDestruct = '5',
+  Resume = '6',
+  Balance = '7',
+  Extcodesize = '8',
+  Extcodehash = '9',
+  Extcodecopy = '10',
+}
+
+export type AccountAccess = {
+  chainInfo: {
+    forkId: string
+    chainId: string
+  }
+  kind: AccountAccessKind
+  account: string
+  accessor: string
+  initialized: boolean
+  oldBalance: string
+  newBalance: string
+  deployedCode: string
+  value: string
+  data: string
+  reverted: boolean
+  storageAccesses: Array<{
+    account: string
+    slot: string
+    isWrite: boolean
+    previousValue: string
+    newValue: string
+    reverted: boolean
+  }>
+}
+
+export type ParsedAccountAccess = {
+  root: AccountAccess
+  nested: Array<AccountAccess>
+}
+
+export type DeployedContractSize = {
+  account: string
+  size: string
+}
+
 export type DecodedApproveLeafData = {
   safeProxy: string
   moduleProxy: string

--- a/packages/contracts/test/mocha/moonbeam-gas.spec.ts
+++ b/packages/contracts/test/mocha/moonbeam-gas.spec.ts
@@ -1,0 +1,205 @@
+import { expect } from 'chai'
+
+import { calculateActionLeafGasForMoonbeam } from '../../src/networks'
+import { AccountAccessKind } from '../../src/types'
+
+const ratio = 15_000_000 / (40 * 1024)
+
+describe('calculateActionLeafGasForMoonbeam', () => {
+  it('should calculate correct gas for single call with write', () => {
+    const foundryGas = '10000'
+    const deployedContractSizes = [{ account: '0x123', size: '500' }]
+    const access = {
+      root: {
+        chainInfo: { forkId: '0x01', chainId: '0x01' },
+        kind: AccountAccessKind.Call,
+        account: '0x123',
+        accessor: '0x456',
+        initialized: true,
+        oldBalance: '100',
+        newBalance: '200',
+        deployedCode: '0x...',
+        value: '50',
+        data: '0x...',
+        reverted: false,
+        storageAccesses: [
+          {
+            account: '0x123',
+            slot: '0x01',
+            isWrite: true,
+            previousValue: '0',
+            newValue: '1',
+            reverted: false,
+          },
+        ],
+      },
+      nested: [],
+    }
+
+    // The overhead on moonbeam is ratio = ~367
+    // So we can calculate the expected gas by adding up the bytes we expected to be stored * the ratio
+    // Expected gas = foundry cost + (storage access 32 bytes * ratio)
+    const expectedGas = Math.ceil(Number(foundryGas) + ratio * 32)
+    const result = calculateActionLeafGasForMoonbeam(
+      foundryGas,
+      deployedContractSizes,
+      access
+    )
+
+    expect(result).to.eq(expectedGas.toString())
+  })
+
+  it('should handle no storage writes', () => {
+    const foundryGas = '0'
+    const deployedContractSizes = []
+    const access = {
+      root: {
+        chainInfo: { forkId: '0x01', chainId: '0x01' },
+        kind: AccountAccessKind.Call,
+        account: '0x123',
+        accessor: '0x456',
+        initialized: false,
+        oldBalance: '0',
+        newBalance: '0',
+        deployedCode: '',
+        value: '0',
+        data: '',
+        reverted: false,
+        storageAccesses: [],
+      },
+      nested: [],
+    }
+
+    // Since we don't do any writes in this test and the input foundryGas is 0, we expect the output gas to be 0
+    const expectedGas = '0'
+    const result = calculateActionLeafGasForMoonbeam(
+      foundryGas,
+      deployedContractSizes,
+      access
+    )
+    expect(result).to.eq(expectedGas)
+  })
+
+  it('should handle a transaction that deploys a contract with storage writes in the constructor', () => {
+    const foundryGas = '50000'
+    const deployedContractSizes = [{ account: '0xContract', size: '800' }]
+    const access = {
+      root: {
+        chainInfo: { forkId: '0x01', chainId: '0x01' },
+        kind: AccountAccessKind.Create,
+        account: '0xContract',
+        accessor: '0xDeployer',
+        initialized: true,
+        oldBalance: '0',
+        newBalance: '0',
+        deployedCode: '0xContractCode...',
+        value: '0',
+        data: '0xConstructorArguments...',
+        reverted: false,
+        storageAccesses: [
+          {
+            account: '0xContract',
+            slot: '0x01',
+            isWrite: true,
+            previousValue: '0',
+            newValue: '100',
+            reverted: false,
+          },
+          {
+            account: '0xContract',
+            slot: '0x02',
+            isWrite: false, // should not record storage usage for this
+            previousValue: '0',
+            newValue: '200',
+            reverted: false,
+          },
+          {
+            account: '0xContract',
+            slot: '0x03',
+            isWrite: true,
+            previousValue: '0',
+            newValue: '200',
+            reverted: false,
+          },
+        ],
+      },
+      nested: [],
+    }
+
+    // For contracts the gas is the size of the contract * ration - 200 * ratio
+    // Expected gas = foundry cost + (ratio * contract code size) - (200 * contract code size) + (storageAccess 1 bytes * ratio) + (storageAccesses 2 bytes * ratio)
+    const expectedGas = Math.ceil(
+      Number(foundryGas) +
+        ratio * Number(deployedContractSizes[0].size) +
+        -200 * Number(deployedContractSizes[0].size) +
+        32 * ratio +
+        32 * ratio
+    )
+    const result = calculateActionLeafGasForMoonbeam(
+      foundryGas,
+      deployedContractSizes,
+      access
+    )
+    expect(result).to.eq(expectedGas.toString())
+  })
+
+  it('should handle a transaction that does a write and then deploys a contract', () => {
+    const foundryGas = '60000'
+    const deployedContractSizes = [{ account: '0xNewContract', size: '900' }]
+    const access = {
+      root: {
+        chainInfo: { forkId: '0x01', chainId: '0x01' },
+        kind: AccountAccessKind.Call,
+        account: '0xExistingAccount',
+        accessor: '0xCaller',
+        initialized: true,
+        oldBalance: '100',
+        newBalance: '150',
+        deployedCode: '',
+        value: '0',
+        data: '0xSomeData...',
+        reverted: false,
+        storageAccesses: [
+          {
+            account: '0xExistingAccount',
+            slot: '0x01',
+            isWrite: true,
+            previousValue: '0',
+            newValue: '100',
+            reverted: false,
+          },
+        ],
+      },
+      nested: [
+        {
+          chainInfo: { forkId: '0x01', chainId: '0x01' },
+          kind: AccountAccessKind.Create,
+          account: '0xNewContract',
+          accessor: '0xCaller',
+          initialized: true,
+          oldBalance: '0',
+          newBalance: '0',
+          deployedCode: '0xNewContractCode...',
+          value: '0',
+          data: '0xConstructorArguments...',
+          reverted: false,
+          storageAccesses: [],
+        },
+      ],
+    }
+
+    // Expected gas = foundry cost + (ratio * new contract code size) - (200 * new contract code size) + (storageAccess 32 bytes * ratio)
+    const expectedGas = Math.ceil(
+      Number(foundryGas) +
+        ratio * Number(deployedContractSizes[0].size) +
+        -200 * Number(deployedContractSizes[0].size) +
+        32 * ratio
+    )
+    const result = calculateActionLeafGasForMoonbeam(
+      foundryGas,
+      deployedContractSizes,
+      access
+    )
+    expect(result).to.eq(expectedGas.toString())
+  })
+})

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -9,6 +9,8 @@ import {
   SphinxTransaction,
   ContractArtifact,
   SphinxMerkleTree,
+  ParsedAccountAccess,
+  DeployedContractSize,
 } from '@sphinx-labs/contracts'
 
 import { BuildInfo, CompilerInput } from '../languages/solidity/types'
@@ -93,11 +95,6 @@ export type NetworkConfig = {
   gitCommit: string | null
 }
 
-export type ParsedAccountAccess = {
-  root: AccountAccess
-  nested: Array<AccountAccess>
-}
-
 export type DeploymentInfo = {
   safeAddress: string
   moduleAddress: string
@@ -115,6 +112,7 @@ export type DeploymentInfo = {
   sphinxLibraryVersion: string
   accountAccesses: Array<ParsedAccountAccess>
   gasEstimates: Array<string>
+  deployedContractSizes: Array<DeployedContractSize>
 }
 
 export type InitialChainState = {
@@ -285,43 +283,4 @@ export interface FoundryDryRunTransaction extends AbstractFoundryTransaction {
 export interface FoundryBroadcastTransaction
   extends AbstractFoundryTransaction {
   hash: string
-}
-
-export enum AccountAccessKind {
-  Call = '0',
-  DelegateCall = '1',
-  CallCode = '2',
-  StaticCall = '3',
-  Create = '4',
-  SelfDestruct = '5',
-  Resume = '6',
-  Balance = '7',
-  Extcodesize = '8',
-  Extcodehash = '9',
-  Extcodecopy = '10',
-}
-
-export type AccountAccess = {
-  chainInfo: {
-    forkId: string
-    chainId: string
-  }
-  kind: AccountAccessKind
-  account: string
-  accessor: string
-  initialized: boolean
-  oldBalance: string
-  newBalance: string
-  deployedCode: string
-  value: string
-  data: string
-  reverted: boolean
-  storageAccesses: Array<{
-    account: string
-    slot: string
-    isWrite: boolean
-    previousValue: string
-    newValue: string
-    reverted: boolean
-  }>
 }

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -2,6 +2,10 @@
 // Be careful when importing external dependencies to this file because they may cause issues when this file
 // is imported by the website.
 import {
+  DeployedContractSize,
+  ParsedAccountAccess,
+} from '@sphinx-labs/contracts'
+import {
   SPHINX_LOCAL_NETWORKS,
   SPHINX_NETWORKS,
 } from '@sphinx-labs/contracts/dist/networks'
@@ -119,6 +123,25 @@ export const fetchDripVersionForNetwork = (chainId: bigint) => {
     return network.dripVersion
   } else {
     throw new Error(`Unsupported network id ${chainId}`)
+  }
+}
+
+export const calculateMerkleLeafGas = (
+  chainId: bigint,
+  foundryGas: string,
+  deployedContractSizes: DeployedContractSize[],
+  access: ParsedAccountAccess
+) => {
+  const network = SPHINX_NETWORKS.find((n) => n.chainId === chainId)
+
+  if (network?.handleNetworkSpecificMerkleLeafGas) {
+    return network.handleNetworkSpecificMerkleLeafGas(
+      foundryGas,
+      deployedContractSizes,
+      access
+    )
+  } else {
+    return foundryGas
   }
 }
 

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -31,15 +31,12 @@ import {
   zeroOutLibraryReferences,
 } from '@sphinx-labs/core/dist/utils'
 import {
-  AccountAccess,
-  AccountAccessKind,
   ActionInput,
   DeploymentConfig,
   ConfigArtifacts,
   DeploymentInfo,
   GetConfigArtifacts,
   InitialChainState,
-  ParsedAccountAccess,
   NetworkConfig,
   ParsedVariable,
   SphinxConfig,
@@ -70,6 +67,9 @@ import {
   CONTRACTS_LIBRARY_VERSION,
   SPHINX_NETWORKS,
   NetworkType,
+  ParsedAccountAccess,
+  AccountAccessKind,
+  AccountAccess,
 } from '@sphinx-labs/contracts'
 import { ConstructorFragment, ethers } from 'ethers'
 

--- a/packages/plugins/test/mocha/artifacts.spec.ts
+++ b/packages/plugins/test/mocha/artifacts.spec.ts
@@ -5,7 +5,6 @@ import {
   ExecutionMode,
   fetchChainIdForNetwork,
   writeDeploymentArtifacts,
-  ParsedAccountAccess,
   makeContractDeploymentArtifacts,
   SphinxJsonRpcProvider,
   isContractDeploymentArtifact,
@@ -13,7 +12,7 @@ import {
   isExecutionArtifact,
 } from '@sphinx-labs/core'
 import { ethers } from 'ethers'
-import { remove0x } from '@sphinx-labs/contracts'
+import { ParsedAccountAccess, remove0x } from '@sphinx-labs/contracts'
 import sinon from 'sinon'
 import { expect } from 'chai'
 

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -27,9 +27,6 @@ import {
   fetchChainIdForNetwork,
   checkSystemDeployed,
   ensureSphinxAndGnosisSafeDeployed,
-  AccountAccess,
-  AccountAccessKind,
-  ParsedAccountAccess,
   compileAndExecuteDeployment,
   signMerkleRoot,
   Deployment,
@@ -62,6 +59,9 @@ import {
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
   isNonNullObject,
   CONTRACTS_LIBRARY_VERSION,
+  AccountAccess,
+  AccountAccessKind,
+  ParsedAccountAccess,
 } from '@sphinx-labs/contracts'
 import { expect } from 'chai'
 
@@ -432,6 +432,8 @@ export const makeDeployment = async (
         accountAccesses,
         gasEstimates: new Array(numActionInputs).fill(gasEstimateSize),
         sphinxLibraryVersion: CONTRACTS_LIBRARY_VERSION,
+        // This is currenly only used specifically on Moonbeam
+        deployedContractSizes: [],
       }
 
       return deploymentInfo


### PR DESCRIPTION
## Purpose
- Handle [Moonbeams' irregular method of calculating gas](https://docs.moonbeam.network/builders/get-started/eth-compare/tx-fees/) per byte of storage used. 
- Enables the `useHigherMaxGasLimit` option on Moonbeam and related networks.

## Notes
Since Moonbeam has a rather low block gas limit (15 million), and the increased storage costs make it more expensive to deploy contracts, I realized we probably don't support max size limit contracts on Moonbeam or its related networks. I tested this by trying to deploy the DCAHub contract, which I couldn't deploy even with the `useHigherMaxGasLimit` option enabled. It is quite close, though, so we should be able to make it work pretty easily. 

I went ahead and enabled the `useHigherMaxGasLimit` option in this PR. I've created a [separate ticket](https://linear.app/chugsplash/issue/CHU-646/use-ethers-caching-logic-on-website) to ensure we have support for maximum-size-limit contracts on the network.