### PR TITLE
feat(core): Smoothly handle blockexplorer outages on the website

### DIFF
--- a/.changeset/itchy-hornets-marry.md
+++ b/.changeset/itchy-hornets-marry.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Add support for multiple block explorer configurations on each network

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Deployments with Sphinx are a three-step process:
 
 * **Gasless Deployments**: You don't need to worry about securing a funded private key or getting native gas tokens on any chain. We'll bill you in fiat after your deployment is finished. Deployments on testnets are completely free.
 
-* **One-Click Multichain Deployments**: Approve deployments across dozens of networks by signing a single meta transaction. Sphinx's backend will deploy on each network in parallel and verify your smart contracts on Etherscan.
+* **One-Click Multichain Deployments**: Approve deployments across dozens of networks by signing a single meta transaction. Sphinx's backend will deploy on each network in parallel and verify your smart contracts on block explorers.
 
 * **Deployments in CI**: Eliminate human error and improve security by gaslessly triggering deployments from your CI process. You can always propose from your local machine if you'd prefer.
 

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -116,17 +116,28 @@ export const calculateActionLeafGasForMoonbeam = (
   return (baseGasLessStorageCost + moonbeamStorageCost).toString()
 }
 
+export type ExplorerName = 'Blockscout' | 'Etherscan'
+
+export type BlockExplorers = {
+  etherscan?: {
+    apiURL: string
+    browserURL: string
+    envKey: string
+  }
+  blockscout?: {
+    apiURL: string
+    browserURL: string
+    envKey: string
+    selfHosted: boolean
+  }
+}
+
 export type SupportedNetwork = {
   name: string
   displayName: string
   chainId: bigint
   rpcUrl: () => string
-  etherscan: {
-    apiURL: string
-    browserURL: string
-    envKey: string
-    blockExplorer: BlockExplorer
-  }
+  blockexplorers: BlockExplorers
   currency: string
   dripSize: string
   requiredEnvVariables: Array<string>
@@ -171,7 +182,6 @@ export const SPHINX_LOCAL_NETWORKS: Array<SupportedLocalNetwork> = [
   },
 ]
 
-type BlockExplorer = 'Etherscan' | 'Blockscout' | 'Unsupported'
 export type NetworkType = 'Testnet' | 'Mainnet' | 'Local'
 type RollupProvider = 'Conduit' | 'Caldera'
 type RollupType = 'OP Stack' | 'Arbitrum'
@@ -183,11 +193,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(1),
     rpcUrl: () =>
       `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.etherscan.io/api',
-      browserURL: 'https://etherscan.io',
-      envKey: 'ETH_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.etherscan.io/api',
+        browserURL: 'https://etherscan.io',
+        envKey: 'ETH_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://eth.blockscout.com/api',
+        browserURL: 'https://eth.blockscout.com/',
+        envKey: 'ETH_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -207,11 +224,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(11155111),
     rpcUrl: () =>
       `https://eth-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-sepolia.etherscan.io/api',
-      browserURL: 'https://sepolia.etherscan.io',
-      envKey: 'ETH_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-sepolia.etherscan.io/api',
+        browserURL: 'https://sepolia.etherscan.io',
+        envKey: 'ETH_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://eth-sepolia.blockscout.com/api',
+        browserURL: 'https://eth-sepolia.blockscout.com/',
+        envKey: 'ETH_SEPOLIA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -231,11 +255,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(10),
     rpcUrl: () =>
       `https://opt-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-optimistic.etherscan.io/api',
-      browserURL: 'https://optimistic.etherscan.io/',
-      envKey: 'OPT_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-optimistic.etherscan.io/api',
+        browserURL: 'https://optimistic.etherscan.io/',
+        envKey: 'OPT_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://optimism.blockscout.com/api',
+        browserURL: 'https://optimism.blockscout.com/',
+        envKey: 'OPT_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -255,11 +286,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(11155420),
     rpcUrl: () =>
       `https://opt-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-sepolia-optimism.etherscan.io/api',
-      browserURL: 'https://sepolia-optimism.etherscan.io/',
-      envKey: 'OPT_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-sepolia-optimism.etherscan.io/api',
+        browserURL: 'https://sepolia-optimism.etherscan.io/',
+        envKey: 'OPT_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://optimism-sepolia.blockscout.com/api',
+        browserURL: 'https://optimism-sepolia.blockscout.com/',
+        envKey: 'OPT_SEPOLIA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -279,11 +317,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(42161),
     rpcUrl: () =>
       `https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.arbiscan.io/api',
-      browserURL: 'https://arbiscan.io/',
-      envKey: 'ARB_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.arbiscan.io/api',
+        browserURL: 'https://arbiscan.io/',
+        envKey: 'ARB_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -303,11 +342,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(421614),
     rpcUrl: () =>
       `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-sepolia.arbiscan.io/api',
-      browserURL: 'https://sepolia.arbiscan.io/',
-      envKey: 'ARB_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-sepolia.arbiscan.io/api',
+        browserURL: 'https://sepolia.arbiscan.io/',
+        envKey: 'ARB_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -327,11 +367,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(137),
     rpcUrl: () =>
       `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.polygonscan.com/api',
-      browserURL: 'https://polygonscan.com',
-      envKey: 'POLYGON_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.polygonscan.com/api',
+        browserURL: 'https://polygonscan.com',
+        envKey: 'POLYGON_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'MATIC',
     dripSize: '1',
@@ -351,11 +392,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(80001),
     rpcUrl: () =>
       `https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-testnet.polygonscan.com/api',
-      browserURL: 'https://mumbai.polygonscan.com/',
-      envKey: 'POLYGON_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet.polygonscan.com/api',
+        browserURL: 'https://mumbai.polygonscan.com/',
+        envKey: 'POLYGON_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'MATIC',
     dripSize: '1',
@@ -374,11 +416,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Binance Smart Chain',
     chainId: BigInt(56),
     rpcUrl: () => process.env.BNB_MAINNET_URL!,
-    etherscan: {
-      apiURL: 'https://api.bscscan.com/api',
-      browserURL: 'https://bscscan.com',
-      envKey: 'BNB_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.bscscan.com/api',
+        browserURL: 'https://bscscan.com',
+        envKey: 'BNB_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'BNB',
     dripSize: '0.05',
@@ -397,11 +440,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Binance Smart Chain Testnet',
     chainId: BigInt(97),
     rpcUrl: () => process.env.BNB_TESTNET_URL!,
-    etherscan: {
-      apiURL: 'https://api-testnet.bscscan.com/api',
-      browserURL: 'https://testnet.bscscan.com',
-      envKey: 'BNB_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet.bscscan.com/api',
+        browserURL: 'https://testnet.bscscan.com',
+        envKey: 'BNB_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'BNB',
     dripSize: '0.15',
@@ -420,11 +464,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Gnosis',
     chainId: BigInt(100),
     rpcUrl: () => process.env.GNOSIS_MAINNET_URL!,
-    etherscan: {
-      apiURL: 'https://api.gnosisscan.io/api',
-      browserURL: 'https://gnosisscan.io',
-      envKey: 'GNOSIS_MAINNET_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.gnosisscan.io/api',
+        browserURL: 'https://gnosisscan.io',
+        envKey: 'GNOSIS_MAINNET_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://gnosis-chiado.blockscout.com/api',
+        browserURL: 'https://gnosis-chiado.blockscout.com/',
+        envKey: 'GNOSIS_MAINNET_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'xDAI',
     dripSize: '1',
@@ -443,11 +494,13 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Gnosis Chiado',
     chainId: BigInt(10200),
     rpcUrl: () => process.env.CHIADO_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://gnosis-chiado.blockscout.com/api',
-      browserURL: 'https://gnosis-chiado.blockscout.com',
-      envKey: 'GNOSIS_CHIADO_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://gnosis-chiado.blockscout.com/api',
+        browserURL: 'https://gnosis-chiado.blockscout.com',
+        envKey: 'GNOSIS_CHIADO_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'xDAI',
     dripSize: '0.15',
@@ -467,11 +520,19 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(59144),
     rpcUrl: () =>
       `https://linea-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.lineascan.build/api',
-      browserURL: 'https://lineascan.build',
-      envKey: 'LINEA_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.lineascan.build/api',
+        browserURL: 'https://lineascan.build',
+        envKey: 'LINEA_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://explorer.goerli.linea.build/api',
+        browserURL: 'https://explorer.goerli.linea.build/',
+        // key is not required on this network
+        envKey: 'LINEA_BLOCKSCOUT_API_KEY',
+        selfHosted: true,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -491,11 +552,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(59140),
     rpcUrl: () =>
       `https://linea-goerli.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-goerli.lineascan.build/api',
-      browserURL: 'https://goerli.lineascan.build',
-      envKey: 'LINEA_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-goerli.lineascan.build/api',
+        browserURL: 'https://goerli.lineascan.build',
+        envKey: 'LINEA_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -514,11 +576,19 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Polygon zkEVM',
     chainId: BigInt(1101),
     rpcUrl: () => process.env.POLYGON_ZKEVM_MAINNET_URL!,
-    etherscan: {
-      apiURL: 'https://api-zkevm.polygonscan.com/api',
-      browserURL: 'https://zkevm.polygonscan.com/',
-      envKey: 'POLYGON_ZKEVM_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-zkevm.polygonscan.com/api',
+        browserURL: 'https://zkevm.polygonscan.com/',
+        envKey: 'POLYGON_ZKEVM_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://zkevm.blockscout.com/api',
+        browserURL: 'https://zkevm.blockscout.com/',
+        // key is not required on this network
+        envKey: 'POLYGON_ZKEVM_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -537,11 +607,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Polygon zkEVM Goerli',
     chainId: BigInt(1442),
     rpcUrl: () => process.env.POLYGON_ZKEVM_TESTNET_URL!,
-    etherscan: {
-      apiURL: 'https://api-testnet-zkevm.polygonscan.com/api',
-      browserURL: 'https://testnet-zkevm.polygonscan.com',
-      envKey: 'POLYGON_ZKEVM_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet-zkevm.polygonscan.com/api',
+        browserURL: 'https://testnet-zkevm.polygonscan.com',
+        envKey: 'POLYGON_ZKEVM_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -561,11 +632,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(43114),
     rpcUrl: () =>
       `https://avalanche-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.snowtrace.io/api',
-      browserURL: 'https://snowtrace.io/',
-      envKey: 'AVAX_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.snowtrace.io/api',
+        browserURL: 'https://snowtrace.io/',
+        envKey: 'AVAX_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'AVAX',
     dripSize: '1',
@@ -585,11 +657,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(43113),
     rpcUrl: () =>
       `https://avalanche-fuji.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-testnet.snowtrace.io/api',
-      browserURL: 'https://testnet.snowtrace.io/',
-      envKey: 'AVAX_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet.snowtrace.io/api',
+        browserURL: 'https://testnet.snowtrace.io/',
+        envKey: 'AVAX_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'AVAX',
     dripSize: '1',
@@ -608,11 +681,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Fantom',
     chainId: BigInt(250),
     rpcUrl: () => process.env.FANTOM_MAINNET_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api.ftmscan.com/api',
-      browserURL: 'https://ftmscan.com',
-      envKey: 'FANTOM_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.ftmscan.com/api',
+        browserURL: 'https://ftmscan.com',
+        envKey: 'FANTOM_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'FTM',
     dripSize: '1',
@@ -631,12 +705,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Fantom Testnet',
     chainId: BigInt(4002),
     rpcUrl: () => process.env.FANTOM_TESTNET_RPC_URL!,
-    etherscan: {
-      apiURL: '',
-      browserURL: '',
-      envKey: '',
-      blockExplorer: 'Unsupported',
-    },
+    blockexplorers: {},
     currency: 'FTM',
     dripSize: '1',
     requiredEnvVariables: ['FANTOM_TESTNET_RPC_URL'],
@@ -655,11 +724,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(8453),
     rpcUrl: () =>
       `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.basescan.org/api',
-      browserURL: 'https://basescan.org/',
-      envKey: 'BASE_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.basescan.org/api',
+        browserURL: 'https://basescan.org/',
+        envKey: 'BASE_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://base.blockscout.com/api',
+        browserURL: 'https://base.blockscout.com/',
+        envKey: 'BASE_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -679,11 +755,18 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(84532),
     rpcUrl: () =>
       `https://base-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://base-sepolia.blockscout.com/api',
-      browserURL: 'https://base-sepolia.blockscout.com/',
-      envKey: 'BASE_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-sepolia.basescan.org/',
+        browserURL: 'https://sepolia.basescan.org/',
+        envKey: 'BASE_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://base-sepolia.blockscout.com/api',
+        browserURL: 'https://base-sepolia.blockscout.com/',
+        envKey: 'BASE_SEPOLIA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -703,11 +786,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(42220),
     rpcUrl: () =>
       `https://celo-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api.celoscan.io/api',
-      browserURL: 'https://celoscan.io/',
-      envKey: 'CELO_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.celoscan.io/api',
+        browserURL: 'https://celoscan.io/',
+        envKey: 'CELO_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'CELO',
     dripSize: '1',
@@ -727,11 +811,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     chainId: BigInt(44787),
     rpcUrl: () =>
       `https://celo-alfajores.infura.io/v3/${process.env.INFURA_API_KEY}`,
-    etherscan: {
-      apiURL: 'https://api-alfajores.celoscan.io/api',
-      browserURL: 'https://alfajores.celoscan.io/',
-      envKey: 'CELO_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-alfajores.celoscan.io/api',
+        browserURL: 'https://alfajores.celoscan.io/',
+        envKey: 'CELO_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'CELO',
     dripSize: '0.15',
@@ -750,11 +835,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Moonriver',
     chainId: BigInt(1285),
     rpcUrl: () => process.env.MOONRIVER_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api-moonriver.moonscan.io/api',
-      browserURL: 'https://moonriver.moonscan.io',
-      envKey: 'MOONRIVER_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-moonriver.moonscan.io/api',
+        browserURL: 'https://moonriver.moonscan.io',
+        envKey: 'MOONRIVER_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'MOVR',
     dripSize: '0.15',
@@ -774,11 +860,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Moonbeam',
     chainId: BigInt(1284),
     rpcUrl: () => process.env.MOONBEAM_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api-moonbeam.moonscan.io/api',
-      browserURL: 'https://moonbeam.moonscan.io',
-      envKey: 'MOONBEAM_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-moonbeam.moonscan.io/api',
+        browserURL: 'https://moonbeam.moonscan.io',
+        envKey: 'MOONBEAM_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'GLMR',
     dripSize: '1',
@@ -798,11 +885,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Moonbase Alpha',
     chainId: BigInt(1287),
     rpcUrl: () => process.env.MOONBASE_ALPHA_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api-moonbase.moonscan.io/api',
-      browserURL: 'https://moonbase.moonscan.io/',
-      envKey: 'MOONBEAM_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-moonbase.moonscan.io/api',
+        browserURL: 'https://moonbase.moonscan.io/',
+        envKey: 'MOONBEAM_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'GLMR',
     dripSize: '0.05',
@@ -822,11 +910,13 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Fuse',
     chainId: BigInt(122),
     rpcUrl: () => process.env.FUSE_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://explorer.fuse.io/api',
-      browserURL: 'https://explorer.fuse.io',
-      envKey: 'FUSE_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://explorer.fuse.io/api',
+        browserURL: 'https://explorer.fuse.io',
+        envKey: 'FUSE_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'FUSE',
     dripSize: '1',
@@ -845,13 +935,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Evmos',
     chainId: BigInt(9001),
     rpcUrl: () => process.env.EVMOS_RPC_URL!,
-    etherscan: {
-      // Need to support sourcify
-      apiURL: '',
-      browserURL: '',
-      envKey: '',
-      blockExplorer: 'Unsupported',
-    },
+    blockexplorers: {},
     currency: 'EVMOS',
     dripSize: '1',
     requiredEnvVariables: ['EVMOS_RPC_URL'],
@@ -869,13 +953,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Evmos Testnet',
     chainId: BigInt(9000),
     rpcUrl: () => process.env.EVMOS_TESTNET_RPC_URL!,
-    etherscan: {
-      // Need to support sourcify
-      apiURL: '',
-      browserURL: '',
-      envKey: '',
-      blockExplorer: 'Unsupported',
-    },
+    blockexplorers: {},
     currency: 'EVMOS',
     dripSize: '0.015',
     requiredEnvVariables: ['EVMOS_TESTNET_RPC_URL'],
@@ -893,11 +971,14 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Kava',
     chainId: BigInt(2222),
     rpcUrl: () => process.env.KAVA_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://kavascan.com/api',
-      browserURL: 'https://kavascan.com',
-      envKey: 'KAVA_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://kavascan.com/api',
+        browserURL: 'https://kavascan.com',
+        // key is not required on this network
+        envKey: 'KAVA_ETHERSCAN_API_KEY',
+        selfHosted: true,
+      },
     },
     currency: 'KAVA',
     dripSize: '1',
@@ -916,14 +997,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Kava Testnet',
     chainId: BigInt(2221),
     rpcUrl: () => process.env.KAVA_TESTNET_RPC_URL!,
-    etherscan: {
-      // Need to support sourcify
-      // They have blockscout, but the api is non-responsive
-      apiURL: '',
-      browserURL: '',
-      envKey: '',
-      blockExplorer: 'Unsupported',
-    },
+    blockexplorers: {},
     currency: 'KAVA',
     dripSize: '1',
     requiredEnvVariables: ['KAVA_TESTNET_RPC_URL'],
@@ -941,12 +1015,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'OKT Chain',
     chainId: BigInt(66),
     rpcUrl: () => process.env.OKTC_RPC_URL!,
-    etherscan: {
-      apiURL: '',
-      browserURL: '',
-      envKey: '',
-      blockExplorer: 'Unsupported',
-    },
+    blockexplorers: {},
     currency: 'OKT',
     dripSize: '1',
     requiredEnvVariables: ['OKTC_RPC_URL'],
@@ -964,11 +1033,19 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Scroll',
     chainId: BigInt(534352),
     rpcUrl: () => process.env.SCROLL_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api.scrollscan.com/api',
-      browserURL: 'https://scrollscan.com/',
-      envKey: 'SCROLL_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.scrollscan.com/api',
+        browserURL: 'https://scrollscan.com/',
+        envKey: 'SCROLL_ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://blockscout.scroll.io/api',
+        browserURL: 'https://blockscout.scroll.io/api',
+        // key is not required on this network
+        envKey: 'SCROLL_BLOCKSCOUT_API_KEY',
+        selfHosted: true,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -987,11 +1064,12 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Scroll Sepolia',
     chainId: BigInt(534351),
     rpcUrl: () => process.env.SCROLL_TESTNET_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://api-sepolia.scrollscan.com/api',
-      browserURL: 'https://sepolia.scrollscan.com/',
-      envKey: 'SCROLL_ETHERSCAN_API_KEY',
-      blockExplorer: 'Etherscan',
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-sepolia.scrollscan.com/api',
+        browserURL: 'https://sepolia.scrollscan.com/',
+        envKey: 'SCROLL_ETHERSCAN_API_KEY',
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -1010,11 +1088,13 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Rootstock',
     chainId: BigInt(30),
     rpcUrl: () => process.env.ROOTSTOCK_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://rootstock.blockscout.com/api',
-      browserURL: 'https://rootstock.blockscout.com/',
-      envKey: 'ROOTSTOCK_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://rootstock.blockscout.com/api',
+        browserURL: 'https://rootstock.blockscout.com/',
+        envKey: 'ROOTSTOCK_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'RBTC',
     dripSize: '0.001',
@@ -1033,11 +1113,13 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Rootstock Testnet',
     chainId: BigInt(31),
     rpcUrl: () => process.env.ROOTSTOCK_TESTNET_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://rootstock-testnet.blockscout.com/api',
-      browserURL: 'https://rootstock-testnet.blockscout.com/',
-      envKey: 'ROOTSTOCK_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://rootstock-testnet.blockscout.com/api',
+        browserURL: 'https://rootstock-testnet.blockscout.com/',
+        envKey: 'ROOTSTOCK_TESTNET_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'RBTC',
     dripSize: '0.001',
@@ -1056,11 +1138,14 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Zora',
     chainId: BigInt(7777777),
     rpcUrl: () => process.env.ZORA_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://explorer.zora.energy/api',
-      browserURL: 'https://explorer.zora.energy/',
-      envKey: 'ZORA_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://explorer.zora.energy/api',
+        browserURL: 'https://explorer.zora.energy/',
+        // key is not necessary on this network
+        envKey: 'ZORA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -1083,11 +1168,14 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'Zora Sepolia',
     chainId: BigInt(999999999),
     rpcUrl: () => process.env.ZORA_SEPOLIA_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://sepolia.explorer.zora.energy/api',
-      browserURL: 'https://sepolia.explorer.zora.energy/',
-      envKey: 'ZORA_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://sepolia.explorer.zora.energy/api',
+        browserURL: 'https://sepolia.explorer.zora.energy/',
+        // key is not necessary on this network
+        envKey: 'ZORA_SEPOLIA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',
@@ -1110,11 +1198,14 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'RARI',
     chainId: BigInt(1380012617),
     rpcUrl: () => process.env.RARI_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://mainnet.explorer.rarichain.org/api',
-      browserURL: 'https://mainnet.explorer.rarichain.org/',
-      envKey: 'RARI_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://mainnet.explorer.rarichain.org/api',
+        browserURL: 'https://mainnet.explorer.rarichain.org/',
+        // key is not necessary on this network
+        envKey: 'RARI_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.025',
@@ -1137,11 +1228,14 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     displayName: 'RARI Sepolia',
     chainId: BigInt(1918988905),
     rpcUrl: () => process.env.RARI_SEPOLIA_RPC_URL!,
-    etherscan: {
-      apiURL: 'https://explorer.rarichain.org/api',
-      browserURL: 'https://explorer.rarichain.org/',
-      envKey: 'RARI_ETHERSCAN_API_KEY',
-      blockExplorer: 'Blockscout',
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://explorer.rarichain.org/api',
+        browserURL: 'https://explorer.rarichain.org/',
+        // key is not necessary on this network
+        envKey: 'RARI_SEPOLIA_BLOCKSCOUT_API_KEY',
+        selfHosted: false,
+      },
     },
     currency: 'ETH',
     dripSize: '0.15',

--- a/packages/core/hardhat.config.ts
+++ b/packages/core/hardhat.config.ts
@@ -15,7 +15,7 @@ import ora from 'ora'
 
 import { SphinxJsonRpcProvider } from './src/provider'
 import { SphinxSystemConfig, deploySphinxSystem } from './src/languages'
-import { etherscanVerifySphinxSystem } from './src/etherscan'
+import { verifySphinxSystem } from './src/etherscan'
 import { ExecutionMode } from './src/constants'
 import { isVerificationSupportedForNetwork } from './src/networks'
 
@@ -99,7 +99,7 @@ task('deploy-system')
       if (
         isVerificationSupportedForNetwork((await provider.getNetwork()).chainId)
       ) {
-        await etherscanVerifySphinxSystem(provider, logger)
+        await verifySphinxSystem(provider, logger)
       } else {
         spinner.info('Verification unsupported on this network')
       }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,22 +1,6 @@
-import { ChainConfig } from '@nomicfoundation/hardhat-verify/types'
-import { SPHINX_NETWORKS } from '@sphinx-labs/contracts/dist/networks'
 import { ethers } from 'ethers'
 
 export const WEBSITE_URL = `https://sphinx.dev`
-
-// Etherscan constants
-export const customChains: ChainConfig[] = SPHINX_NETWORKS.filter(
-  (network) => network.etherscan.blockExplorer !== 'Unsupported'
-).map((network) => {
-  return {
-    network: network.name,
-    chainId: Number(network.chainId),
-    urls: {
-      apiURL: network.etherscan.apiURL,
-      browserURL: network.etherscan.browserURL,
-    },
-  }
-})
 
 export type Integration = 'hardhat' | 'foundry'
 

--- a/packages/core/test/verification-config.spec.ts
+++ b/packages/core/test/verification-config.spec.ts
@@ -1,0 +1,193 @@
+import { expect } from 'chai'
+
+import {
+  fetchEtherscanConfigForNetwork,
+  isBlockscoutSupportedForNetwork,
+  isEtherscanSupportedForNetwork,
+  isVerificationSupportedForNetwork,
+} from '../src/networks'
+
+const mockSphinxNetworks: Array<any> = [
+  {
+    name: 'NetworkWithEtherscan',
+    displayName: 'Network With Etherscan',
+    chainId: BigInt(1),
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.etherscan.io',
+        browserURL: 'https://etherscan.io',
+        envKey: 'ETHERSCAN_API_KEY',
+      },
+    },
+  },
+  {
+    name: 'NetworkWithBlockscout',
+    displayName: 'Network With Blockscout',
+    chainId: BigInt(2),
+    blockexplorers: {
+      blockscout: {
+        apiURL: 'https://api.blockscout.com',
+        browserURL: 'https://blockscout.com',
+        envKey: 'BLOCKSCOUT_API_KEY',
+      },
+    },
+  },
+  {
+    name: 'NetworkWithBoth',
+    displayName: 'Network With Both Explorers',
+    chainId: BigInt(3),
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api.etherscan.io',
+        browserURL: 'https://etherscan.io',
+        envKey: 'ETHERSCAN_API_KEY',
+      },
+      blockscout: {
+        apiURL: 'https://api.blockscout.com',
+        browserURL: 'https://blockscout.com',
+        envKey: 'BLOCKSCOUT_API_KEY',
+      },
+    },
+  },
+  {
+    name: 'NetworkWithNeither',
+    displayName: 'Network With Neither Explorer',
+    chainId: BigInt(4),
+    blockexplorers: {},
+  },
+]
+
+describe('Block Explorer Config Fetch', () => {
+  describe('isEtherscanSupportedForNetwork', () => {
+    it('should return true for a network with Etherscan support', () => {
+      const result = isEtherscanSupportedForNetwork(
+        BigInt(1),
+        mockSphinxNetworks
+      )
+      expect(result).to.be.true
+    })
+
+    it('should return false for a network without Etherscan support', () => {
+      const result = isEtherscanSupportedForNetwork(
+        BigInt(2),
+        mockSphinxNetworks
+      )
+      expect(result).to.be.false
+    })
+
+    it('should throw an error for an unsupported network', () => {
+      expect(() =>
+        isEtherscanSupportedForNetwork(BigInt(6), mockSphinxNetworks)
+      ).to.throw()
+    })
+  })
+
+  describe('isBlockscoutSupportedForNetwork', () => {
+    it('should return true for a network with Blockscout support', () => {
+      const result = isBlockscoutSupportedForNetwork(
+        BigInt(2),
+        mockSphinxNetworks
+      )
+      expect(result).to.be.true
+    })
+
+    it('should return false for a network without Blockscout support', () => {
+      const result = isBlockscoutSupportedForNetwork(
+        BigInt(1),
+        mockSphinxNetworks
+      )
+      expect(result).to.be.false
+    })
+
+    it('should throw an error for an unsupported network', () => {
+      expect(() =>
+        isBlockscoutSupportedForNetwork(BigInt(6), mockSphinxNetworks)
+      ).to.throw()
+    })
+  })
+
+  describe('isVerificationSupportedForNetwork', () => {
+    it('should return true for a network supported by either Etherscan or Blockscout', () => {
+      expect(isVerificationSupportedForNetwork(BigInt(1), mockSphinxNetworks))
+        .to.be.true
+      expect(isVerificationSupportedForNetwork(BigInt(2), mockSphinxNetworks))
+        .to.be.true
+    })
+
+    it('should return true for a network supported by both', () => {
+      expect(isVerificationSupportedForNetwork(BigInt(3), mockSphinxNetworks))
+        .to.be.true
+    })
+
+    it('should return false for a network not supported by either Etherscan or Blockscout', () => {
+      expect(isVerificationSupportedForNetwork(BigInt(4), mockSphinxNetworks))
+        .to.be.false
+    })
+
+    it('should throw an error for an unsupported network', () => {
+      expect(() =>
+        isVerificationSupportedForNetwork(BigInt(6), mockSphinxNetworks)
+      ).to.throw()
+    })
+  })
+
+  describe('fetchEtherscanConfigForNetwork', () => {
+    it('should return Etherscan config for a network with Etherscan and explorerName Etherscan', () => {
+      const config = fetchEtherscanConfigForNetwork(
+        BigInt(1),
+        'Etherscan',
+        mockSphinxNetworks
+      )
+      expect(config).to.have.property('apiURL', 'https://api.etherscan.io')
+    })
+
+    it('should return Blockscout config for a network with Blockscout and explorerName Blockscout', () => {
+      const config = fetchEtherscanConfigForNetwork(
+        BigInt(2),
+        'Blockscout',
+        mockSphinxNetworks
+      )
+      expect(config).to.have.property('apiURL', 'https://api.blockscout.com')
+    })
+
+    it('should return Etherscan config for a network with Etherscan when no explorerName is provided', () => {
+      const config = fetchEtherscanConfigForNetwork(
+        BigInt(1),
+        undefined,
+        mockSphinxNetworks
+      )
+      expect(config).to.have.property('apiURL', 'https://api.etherscan.io')
+    })
+
+    it('should return Blockscout config for a network with only Blockscout when no explorerName is provided', () => {
+      const config = fetchEtherscanConfigForNetwork(
+        BigInt(2),
+        undefined,
+        mockSphinxNetworks
+      )
+      expect(config).to.have.property('apiURL', 'https://api.blockscout.com')
+    })
+
+    it('should throw an error for a network where neither explorer is available when no explorerName is provided', () => {
+      expect(() =>
+        fetchEtherscanConfigForNetwork(BigInt(4), undefined, mockSphinxNetworks)
+      ).to.throw()
+    })
+
+    it('should throw an error for an unsupported network', () => {
+      expect(() =>
+        fetchEtherscanConfigForNetwork(BigInt(6), undefined, mockSphinxNetworks)
+      ).to.throw()
+    })
+
+    it('should throw an error for a supported network but unsupported explorerName', () => {
+      expect(() =>
+        fetchEtherscanConfigForNetwork(
+          BigInt(1),
+          'Unknown' as any,
+          mockSphinxNetworks
+        )
+      ).to.throw()
+    })
+  })
+})

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -363,15 +363,11 @@ export const deploy = async (
     handleExecutionFailure: (
       _deploymentContext: DeploymentContext,
       _networkConfig: NetworkConfig,
-      _configArtifacts: ConfigArtifacts,
       failureReason: HumanReadableAction
     ) => {
       throw new Error(
         `The following action reverted during the execution:\n${failureReason.reason}`
       )
-    },
-    verify: async () => {
-      return
     },
     handleSuccess: async () => {
       return

--- a/packages/plugins/src/hardhat/simulate.ts
+++ b/packages/plugins/src/hardhat/simulate.ts
@@ -18,7 +18,6 @@ import {
   Deployment,
   DeploymentConfig,
   DeploymentContext,
-  ConfigArtifacts,
   HumanReadableAction,
   executeTransactionViaSigner,
   getSphinxWalletsSortedByAddress,
@@ -314,15 +313,11 @@ export const simulateDeploymentSubtask = async (
     handleExecutionFailure: (
       _deploymentContext: DeploymentContext,
       _networkConfig: NetworkConfig,
-      _configArtifacts: ConfigArtifacts,
       failureReason: HumanReadableAction
     ) => {
       throw new Error(
         `The following action reverted during the simulation:\n${failureReason.reason}`
       )
-    },
-    verify: async () => {
-      return
     },
     handleSuccess: async () => {
       return

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -572,9 +572,6 @@ export const runDeployment = async (
       handleExecutionFailure: async () => {
         return
       },
-      verify: async () => {
-        return
-      },
       handleSuccess: async () => {
         return
       },


### PR DESCRIPTION
## Purpose
- Changes the `etherscan` field in the SPHINX_NETWORKS array to support multiple block explorers
- Adds support for Blockscout on all networks where it's running
- Changes the name of some of the environment variables used for block explorer keys to clearly differentiate between etherscan and blockscout
- Adds logic to the deploy task to handle choosing the block explorer if there are multiple available. We chose etherscan if available before falling back to blockscout