### PR TITLE
fix(pg): Remove FOUNDRY_SENDER when collecting transactions

### DIFF
--- a/.changeset/warm-shirts-rhyme.md
+++ b/.changeset/warm-shirts-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Remove FOUNDRY_SENDER during collection phase

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -224,7 +224,6 @@ export const deploy = async (
     // gas. We use the `FOUNDRY_BLOCK_GAS_LIMIT` environment variable because it has a higher
     // priority than `DAPP_BLOCK_GAS_LIMIT`.
     FOUNDRY_BLOCK_GAS_LIMIT: MAX_UINT64.toString(),
-    FOUNDRY_SENDER: safeAddress,
     ETH_FROM: safeAddress,
   })
 

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -129,7 +129,6 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
       // gas. We use the `FOUNDRY_BLOCK_GAS_LIMIT` environment variable because it has a higher
       // priority than `DAPP_BLOCK_GAS_LIMIT`.
       FOUNDRY_BLOCK_GAS_LIMIT: MAX_UINT64.toString(),
-      FOUNDRY_SENDER: safeAddress,
       ETH_FROM: safeAddress,
     })
 


### PR DESCRIPTION
## Purpose
Removes `FOUNDRY_SENDER` during the collection step.