### PR TITLE
fix(pg): check that contracts are deployed in simulation

### DIFF
--- a/.changeset/clever-turtles-applaud.md
+++ b/.changeset/clever-turtles-applaud.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Check that contracts are deployed in simulation

--- a/packages/core/src/actions/execute.ts
+++ b/packages/core/src/actions/execute.ts
@@ -1310,3 +1310,27 @@ export const compileAndExecuteDeployment = async (
     }
   }
 }
+
+/**
+ * An object that contains functions defined in this file. We use this object to mock its member
+ * functions in tests. It's easiest to explain why this object is necessary through an example. Say
+ * this object doesn't exist, and say we have a function `myFunction` that calls
+ * `compileAndExecuteDeployment`. To mock `compileAndExecuteDeployment` when testing `myFunction`,
+ * we'd write:
+ * ```
+ * import * as sphinxCore from '@sphinx-labs/core'
+ * sinon.stub(sphinxCore, 'compileAndExecuteDeployment')
+ * ```
+ * However, the above code will fail with the following error: "TypeError: Descriptor for property
+ * compileAndExecuteDeployment is non-configurable and non-writable".
+ *
+ * Then, say we introduce this object and we update `myFunction` to contain
+ *  `sphinxCoreExecute.compileAndExecuteDeployment`. We can sucessfully create the mock by writing:
+ * ```
+ * import { sphinxCoreExecute } from '@sphinx-labs/core'
+ * sinon.stub(sphinxCoreExecute, 'compileAndExecuteDeployment')
+ *```
+ */
+export const sphinxCoreExecute = {
+  compileAndExecuteDeployment,
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * An error that should only be thrown if there's a bug in Sphinx.
+ */
+export class InvariantError extends Error {
+  constructor(message: string) {
+    super(
+      `${message}.\n` +
+        `Should never happen. Please report this error to the Sphinx team.`
+    )
+    this.name = 'InvariantError'
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // Converts BigInt values to strings when calling JSON.stringify. An error would be thrown
 // otherwise. For more context, see these sources:
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+
 // https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-1006088574
 BigInt.prototype['toJSON'] = function () {
   return this.toString()
@@ -19,3 +20,4 @@ export * from './preview'
 export * from './provider'
 export * from './artifacts'
 export * from './types'
+export * from './errors'

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1544,7 +1544,7 @@ export const isCreateActionInput = (
     typeof create.value === 'string' &&
     typeof create.txData === 'string' &&
     typeof create.gas === 'string' &&
-    create.operation === Operation.Call &&
+    create.operation === Operation.DelegateCall &&
     typeof create.requireSuccess === 'boolean'
   )
 }
@@ -1633,6 +1633,18 @@ export const readDeploymentArtifactsForNetwork = (
 }
 
 export const isArrayMixed = <T>(arr: T[]): boolean => new Set(arr).size > 1
+
+export const getContractAddressesFromNetworkConfig = (
+  networkConfig: NetworkConfig
+): Array<string> => {
+  const unlabeledAddresses = networkConfig.unlabeledContracts.map(
+    (ct) => ct.address
+  )
+  const labeledAddresses = networkConfig.actionInputs
+    .flatMap((actions) => actions.contracts)
+    .map((ct) => ct.address)
+  return unlabeledAddresses.concat(labeledAddresses)
+}
 
 /**
  * Checks if a string contains an opening then closing parenthesis.

--- a/packages/plugins/contracts/test/script/Simple.s.sol
+++ b/packages/plugins/contracts/test/script/Simple.s.sol
@@ -41,3 +41,18 @@ contract Simple2 is Script, Sphinx {
         new MyContract2{ salt: bytes32(uint(2)) }();
     }
 }
+
+contract Simple3 is Script, Sphinx {
+    function configureSphinx() public override {
+        sphinxConfig.projectName = "Simple_Project_3";
+        sphinxConfig.owners = [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266];
+        sphinxConfig.threshold = 1;
+
+        sphinxConfig.orgId = "test-org-id";
+    }
+
+    function run() public sphinx {
+        MyContract2 myContract = new MyContract2();
+        myContract.incrementMyContract2(2);
+    }
+}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -53,6 +53,7 @@
     "ethers": "^6.7.0",
     "node-fetch": "^2.6.7",
     "ora": "^5.4.1",
+    "p-limit": "^3.1.0",
     "semver": "^7.3.7",
     "sinon": "^17.0.1",
     "solidity-ast": "^0.4.52",

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -38,6 +38,7 @@ import {
   injectRoles,
   removeRoles,
   NetworkConfig,
+  DeploymentArtifacts,
 } from '@sphinx-labs/core'
 import { red } from 'chalk'
 import ora from 'ora'
@@ -78,6 +79,7 @@ export const deploy = async (
   preview?: ReturnType<typeof getPreview>
   receipts?: Array<SphinxTransactionReceipt>
   configArtifacts?: ConfigArtifacts
+  deploymentArtifacts?: DeploymentArtifacts
 }> => {
   const {
     network,
@@ -465,5 +467,6 @@ export const deploy = async (
     preview,
     receipts,
     configArtifacts,
+    deploymentArtifacts,
   }
 }

--- a/packages/plugins/test/mocha/cli/deploy.spec.ts
+++ b/packages/plugins/test/mocha/cli/deploy.spec.ts
@@ -6,7 +6,6 @@ import chaiAsPromised from 'chai-as-promised'
 import {
   DeploymentConfig,
   ConfigArtifacts,
-  Create2ActionInput,
   DeploymentArtifacts,
   ExecutionMode,
   NetworkConfig,
@@ -19,12 +18,17 @@ import {
   makeDeploymentArtifacts,
   setBalance,
   isLiveNetwork,
+  InitialChainState,
+  getContractAddressesFromNetworkConfig,
+  ActionInputType,
+  ActionInput,
 } from '@sphinx-labs/core'
-import { ethers } from 'ethers'
+import { ethers, keccak256 } from 'ethers'
 import {
   CREATE3_PROXY_INITCODE,
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
   SphinxMerkleTree,
+  parseFoundryContractArtifact,
 } from '@sphinx-labs/contracts'
 
 import * as MyContract2Artifact from '../../../out/artifacts/MyContracts.sol/MyContract2.json'
@@ -39,8 +43,12 @@ import {
   startAnvilNodes,
   getSphinxModuleAddressFromScript,
   getEmptyDeploymentArtifacts,
+  getGnosisSafeProxyAddress,
+  makeActionInputsWithoutGas,
+  encodeFunctionCalldata,
 } from '../common'
 import { makeMockSphinxContextForIntegrationTests } from '../mock'
+import { getFakeConfigArtifactsFromContractArtifacts } from '../fake'
 
 const coder = new ethers.AbiCoder()
 
@@ -93,12 +101,6 @@ const forgeScriptPath = 'contracts/test/script/Simple.s.sol'
 const emptyScriptPath = 'contracts/test/script/Empty.s.sol'
 const deploymentCasesScriptPath = 'contracts/test/script/Cases.s.sol'
 
-const expectedMyContract2Address = ethers.getCreate2Address(
-  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-  ethers.ZeroHash,
-  ethers.keccak256(MyContract2Artifact.bytecode.object)
-)
-
 const allChainIds = [
   fetchChainIdForNetwork('sepolia'),
   fetchChainIdForNetwork('optimism'),
@@ -136,9 +138,44 @@ describe('Deploy CLI command', () => {
   })
 
   describe('With preview', () => {
-    const projectName = 'Simple_Project_1'
+    it('Executes deployment on local network twice', async () => {
+      const artifact = parseFoundryContractArtifact(MyContract2Artifact)
+      const safeAddress = getGnosisSafeProxyAddress(
+        ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'],
+        1, // Threshold
+        0 // Salt nonce
+      )
 
-    it('Executes deployment on local network', async () => {
+      const nonce = 1
+      const expectedContractAddressOne = ethers.getCreateAddress({
+        from: safeAddress,
+        nonce,
+      })
+      const expectedContractFileNames = ['MyContract2.json']
+      const configArtifacts = await getFakeConfigArtifactsFromContractArtifacts(
+        [artifact]
+      )
+      const expectedActionInputsOne = makeActionInputsWithoutGas(
+        [
+          {
+            actionType: ActionInputType.CREATE,
+            nonce,
+            artifact,
+            from: safeAddress,
+          },
+          {
+            actionType: ActionInputType.CALL,
+            to: expectedContractAddressOne,
+            txData: encodeFunctionCalldata([
+              'incrementMyContract2(uint256)',
+              '2',
+            ]),
+            fullyQualifiedName: `${artifact.sourceName}:${artifact.contractName}`,
+          },
+        ],
+        configArtifacts
+      )
+
       // We run `forge clean` to ensure that a deployment can occur even if there are no existing
       // contract artifacts. This is worthwhile to test because we read contract interfaces in the
       // `deploy` function, which will fail if the function hasn't compiled the contracts yet. By
@@ -149,7 +186,7 @@ describe('Deploy CLI command', () => {
       const executionMode = ExecutionMode.LocalNetworkCLI
 
       expect(
-        await sepoliaProvider.getCode(expectedMyContract2Address)
+        await sepoliaProvider.getCode(expectedContractAddressOne)
       ).to.equal('0x')
 
       // Check that the deployment artifacts have't been created yet
@@ -161,14 +198,8 @@ describe('Deploy CLI command', () => {
       // Use the standard `isLiveNetwork` function so that it returns false.
       context.isLiveNetwork = isLiveNetwork
 
-      const targetContract = 'Simple1'
-      const {
-        deploymentConfig,
-        preview,
-        merkleTree,
-        receipts,
-        configArtifacts,
-      } = await deploy({
+      const targetContract = 'Simple3'
+      const firstDeployment = await deploy({
         scriptPath: forgeScriptPath,
         network: 'sepolia',
         skipPreview: false,
@@ -178,50 +209,78 @@ describe('Deploy CLI command', () => {
         targetContract,
       })
 
-      const networkConfig = deploymentConfig?.networkConfigs.at(0)
+      await expectValidDeployment({
+        deployment: firstDeployment,
+        previousArtifacts: getEmptyDeploymentArtifacts(),
+        provider: sepoliaProvider,
+        expectedExecutionMode: executionMode,
+        expectedContractFileNames,
+        expectedContractAddress: expectedContractAddressOne,
+        expectedInitialState: {
+          isSafeDeployed: false,
+          isModuleDeployed: false,
+          isExecuting: false,
+        },
+        expectedActionInputs: expectedActionInputsOne,
+      })
 
-      // Narrow the TypeScript types.
-      if (
-        !deploymentConfig ||
-        !preview ||
-        !merkleTree ||
-        !receipts ||
-        !configArtifacts ||
-        !networkConfig
-      ) {
+      const expectedContractAddressTwo = ethers.getCreateAddress({
+        from: safeAddress,
+        nonce: 2,
+      })
+      const expectedActionInputsTwo = makeActionInputsWithoutGas(
+        [
+          {
+            actionType: ActionInputType.CREATE,
+            nonce: nonce + 1,
+            artifact,
+            from: safeAddress,
+          },
+          {
+            actionType: ActionInputType.CALL,
+            to: expectedContractAddressTwo,
+            txData: encodeFunctionCalldata([
+              'incrementMyContract2(uint256)',
+              '2',
+            ]),
+            fullyQualifiedName: `${artifact.sourceName}:${artifact.contractName}`,
+          },
+        ],
+        configArtifacts
+      )
+
+      expect(
+        await sepoliaProvider.getCode(expectedContractAddressTwo)
+      ).to.equal('0x')
+
+      const secondDeployment = await deploy({
+        scriptPath: forgeScriptPath,
+        network: 'sepolia',
+        skipPreview: false,
+        silent: true,
+        sphinxContext: context,
+        verify: false,
+        targetContract,
+      })
+
+      if (!firstDeployment.deploymentArtifacts) {
         throw new Error(`Object(s) undefined.`)
       }
 
-      expect(networkConfig.executionMode).equals(executionMode)
-
-      const artifacts: DeploymentArtifacts = {
-        networks: {},
-        compilerInputs: {},
-      }
-      await makeDeploymentArtifacts(
-        {
-          [networkConfig.chainId]: {
-            deploymentConfig,
-            receipts,
-            provider: sepoliaProvider,
-          },
+      await expectValidDeployment({
+        deployment: secondDeployment, // Use the second deployment
+        previousArtifacts: firstDeployment.deploymentArtifacts,
+        provider: sepoliaProvider,
+        expectedExecutionMode: executionMode,
+        expectedContractFileNames,
+        expectedContractAddress: expectedContractAddressTwo,
+        expectedInitialState: {
+          isSafeDeployed: true,
+          isModuleDeployed: true,
+          isExecuting: false,
         },
-        merkleTree.root,
-        configArtifacts,
-        artifacts
-      )
-
-      await expectValidDeployment(
-        deploymentConfig,
-        preview,
-        'sepolia (local)',
-        projectName,
-        artifacts,
-        executionMode,
-        ['MyContract2.json'],
-        expectedMyContract2Address,
-        sepoliaProvider
-      )
+        expectedActionInputs: expectedActionInputsTwo,
+      })
     })
 
     // This tests the logic that deploys on live networks, which uses a signer to call the Sphinx
@@ -232,10 +291,34 @@ describe('Deploy CLI command', () => {
     // name 'optimism' in `SPHINX_NETWORKS`. Changing the network name ensures that the user can
     // deploy with network names that don't match ours.
     it('Executes deployment on live network with non-standard network name', async () => {
+      const create2Salt = '0x' + '00'.repeat(31) + '01'
+      const artifact = parseFoundryContractArtifact(MyContract2Artifact)
       const expectedContractAddressOptimism = ethers.getCreate2Address(
         DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-        '0x' + '00'.repeat(31) + '01',
-        ethers.keccak256(MyContract2Artifact.bytecode.object)
+        create2Salt,
+        keccak256(artifact.bytecode)
+      )
+      const configArtifacts = await getFakeConfigArtifactsFromContractArtifacts(
+        [artifact]
+      )
+      const expectedActionInputs = makeActionInputsWithoutGas(
+        [
+          {
+            actionType: ActionInputType.CREATE2,
+            create2Salt,
+            artifact,
+          },
+          {
+            actionType: ActionInputType.CALL,
+            to: expectedContractAddressOptimism,
+            txData: encodeFunctionCalldata([
+              'incrementMyContract2(uint256)',
+              '2',
+            ]),
+            fullyQualifiedName: `${artifact.sourceName}:${artifact.contractName}`,
+          },
+        ],
+        configArtifacts
       )
 
       expect(
@@ -265,13 +348,7 @@ describe('Deploy CLI command', () => {
       const executionMode = ExecutionMode.LiveNetworkCLI
 
       const targetContract = 'Simple1'
-      const {
-        deploymentConfig,
-        preview,
-        merkleTree,
-        receipts,
-        configArtifacts,
-      } = await deploy({
+      const deployment = await deploy({
         scriptPath: forgeScriptPath,
         network: 'optimism_mainnet',
         skipPreview: false,
@@ -280,57 +357,32 @@ describe('Deploy CLI command', () => {
         verify: false,
         targetContract,
       })
-
-      const networkConfig = deploymentConfig?.networkConfigs.at(0)
-
-      // Narrow the TypeScript types.
-      if (
-        !deploymentConfig ||
-        !preview ||
-        !merkleTree ||
-        !receipts ||
-        !configArtifacts ||
-        !networkConfig
-      ) {
-        throw new Error(`Object(s) undefined.`)
-      }
-
-      expect(networkConfig.executionMode).equals(executionMode)
-
-      const artifacts: DeploymentArtifacts = {
-        networks: {},
-        compilerInputs: {},
-      }
-      await makeDeploymentArtifacts(
-        {
-          [networkConfig.chainId]: {
-            deploymentConfig,
-            receipts,
-            provider: optimismProvider,
-          },
+      await expectValidDeployment({
+        deployment,
+        previousArtifacts: getEmptyDeploymentArtifacts(),
+        provider: optimismProvider,
+        expectedExecutionMode: executionMode,
+        expectedContractFileNames: ['MyContract2.json'],
+        expectedContractAddress: expectedContractAddressOptimism,
+        expectedInitialState: {
+          isSafeDeployed: false,
+          isModuleDeployed: false,
+          isExecuting: false,
         },
-        merkleTree.root,
-        configArtifacts,
-        artifacts
-      )
-
-      await expectValidDeployment(
-        deploymentConfig,
-        preview,
-        'optimism',
-        projectName,
-        artifacts,
-        executionMode,
-        ['MyContract2.json'],
-        expectedContractAddressOptimism,
-        optimismProvider
-      )
+        expectedActionInputs,
+      })
     })
 
     // We exit early even if the Gnosis Safe and Sphinx Module haven't been deployed yet. In other
     // words, we don't allow the user to use the `deploy` CLI command to just deploy a Gnosis Safe
     // and Sphinx Module. This behavior is consistent with the `propose` CLI command.
     it(`Displays preview then exits when there's nothing to execute`, async () => {
+      const expectedMyContract2Address = ethers.getCreate2Address(
+        DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+        ethers.ZeroHash,
+        ethers.keccak256(MyContract2Artifact.bytecode.object)
+      )
+
       expect(
         await sepoliaProvider.getCode(expectedMyContract2Address)
       ).to.equal('0x')
@@ -706,26 +758,57 @@ const getContract = (address: string, artifact: any): ethers.Contract => {
   return contract
 }
 
-const expectValidDeployment = async (
-  deploymentConfig: DeploymentConfig,
-  preview: SphinxPreview,
-  expectedNetworkTag: string,
-  projectName: string,
-  artifacts: DeploymentArtifacts,
-  executionMode: ExecutionMode,
-  expectedContractFileNames: Array<string>,
-  expectedContractAddress: string,
+const expectValidDeployment = async (input: {
+  deployment: Awaited<ReturnType<typeof deploy>>
+  previousArtifacts: DeploymentArtifacts
   provider: SphinxJsonRpcProvider
-) => {
-  const networkConfig = deploymentConfig.networkConfigs.at(0)
+  expectedExecutionMode: ExecutionMode
+  expectedContractFileNames: Array<string>
+  expectedContractAddress: string
+  expectedInitialState: InitialChainState
+  expectedActionInputs: Array<Omit<ActionInput, 'gas'>>
+}) => {
+  const {
+    deployment,
+    previousArtifacts,
+    provider,
+    expectedExecutionMode,
+    expectedContractFileNames,
+    expectedContractAddress,
+    expectedInitialState,
+    expectedActionInputs,
+  } = input
 
-  if (!networkConfig) {
+  const {
+    deploymentConfig,
+    preview,
+    merkleTree,
+    receipts,
+    configArtifacts,
+    deploymentArtifacts,
+  } = deployment
+
+  const networkConfig = deploymentConfig?.networkConfigs.at(0)
+
+  if (
+    !deploymentConfig ||
+    !preview ||
+    !merkleTree ||
+    !receipts ||
+    !configArtifacts ||
+    !networkConfig ||
+    !deploymentArtifacts
+  ) {
     throw new Error(`Object(s) undefined.`)
   }
 
-  expect(
-    (networkConfig.actionInputs[0] as Create2ActionInput).create2Address
-  ).to.equal(expectedContractAddress)
+  expect(networkConfig.executionMode).equals(expectedExecutionMode)
+
+  const contractAddresses = getContractAddressesFromNetworkConfig(networkConfig)
+  for (const address of contractAddresses) {
+    expect(await provider.getCode(address)).does.not.equal('0x')
+  }
+
   const contract = new ethers.Contract(
     expectedContractAddress,
     MyContract2Artifact.abi,
@@ -734,51 +817,20 @@ const expectValidDeployment = async (
   expect(await provider.getCode(expectedContractAddress)).to.not.equal('0x')
   expect(await contract.number()).to.equal(BigInt(2))
 
-  expect(preview).to.deep.equal({
-    networks: [
-      {
-        networkTags: [expectedNetworkTag],
-        executing: [
-          {
-            type: 'SystemDeployment',
-          },
-          {
-            referenceName: 'GnosisSafe',
-            functionName: 'deploy',
-            variables: {},
-            address: networkConfig.safeAddress,
-          },
-          {
-            referenceName: 'SphinxModule',
-            functionName: 'deploy',
-            variables: {},
-            address: networkConfig.moduleAddress,
-          },
-          {
-            referenceName: 'MyContract2',
-            functionName: 'deploy',
-            variables: {},
-            address: expectedContractAddress,
-          },
-          {
-            referenceName: 'MyContract2',
-            functionName: 'incrementMyContract2',
-            variables: { _num: '2' },
-            address: expectedContractAddress,
-          },
-        ],
-        skipping: [],
-      },
-    ],
-    unlabeledAddresses: new Set([]),
-  })
+  expect(networkConfig.initialState).deep.equals(expectedInitialState)
+
+  const actualActionInputsClone = structuredClone(
+    networkConfig.actionInputs
+  ) as any[]
+  actualActionInputsClone.forEach((actionInput) => delete actionInput.gas)
+  expect(actualActionInputsClone).deep.equals(expectedActionInputs)
 
   checkArtifacts(
-    projectName,
+    networkConfig.newConfig.projectName,
     deploymentConfig,
-    getEmptyDeploymentArtifacts(),
-    artifacts,
-    executionMode,
+    previousArtifacts,
+    deploymentArtifacts,
+    expectedExecutionMode,
     expectedContractFileNames
   )
 }

--- a/packages/plugins/test/mocha/dummy.ts
+++ b/packages/plugins/test/mocha/dummy.ts
@@ -5,7 +5,10 @@ import {
   BuildInfos,
   CompilerInput,
   ContractDeploymentArtifact,
+  Deployment,
   DeploymentArtifacts,
+  DeploymentConfig,
+  DeploymentContext,
   ExecutionArtifact,
   ExecutionMode,
   NetworkConfig,
@@ -14,12 +17,14 @@ import {
   SphinxTransactionReceipt,
 } from '@sphinx-labs/core'
 import { ethers } from 'ethers'
+import sinon from 'sinon'
 
 import { makeAddress } from './common'
 
 export const dummyChainId = '43211234'
 export const dummyMerkleRoot = '0x' + 'fe'.repeat(32)
 export const dummyModuleAddress = '0x' + 'df'.repeat(20)
+export const dummyUnlabeledAddress = '0x' + 'ad'.repeat(20)
 export const dummyContractName = 'DummyContractName'
 export const dummyContractArtifactFileName = `${dummyContractName}.json`
 export const dummyExecutionArtifactFileName = `${dummyMerkleRoot}.json`
@@ -219,7 +224,12 @@ export const getDummyNetworkConfig = (): NetworkConfig => {
       isExecuting: false,
     },
     isSystemDeployed: true,
-    unlabeledContracts: [],
+    unlabeledContracts: [
+      {
+        address: dummyUnlabeledAddress,
+        initCodeWithArgs: 'dummyInitCodeWithArgs',
+      },
+    ],
     arbitraryChain: false,
     libraries: [],
     gitCommit: null,
@@ -261,6 +271,17 @@ const getDummyExecutionArtifact = (): ExecutionArtifact => {
   }
 }
 
+export const getDummyDeploymentConfig = (): DeploymentConfig => {
+  return {
+    networkConfigs: [getDummyNetworkConfig()],
+    merkleTree: getDummyMerkleTree(),
+    configArtifacts: {},
+    buildInfos: getDummyBuildInfos(),
+    inputs: [getDummyCompilerInput()],
+    version: 'dummyVersion',
+  }
+}
+
 export const getDummyDeploymentArtifacts = (): DeploymentArtifacts => {
   const { id, input, solcVersion, solcLongVersion } = getDummyBuildInfo()
 
@@ -283,5 +304,38 @@ export const getDummyDeploymentArtifacts = (): DeploymentArtifacts => {
         solcVersion,
       },
     },
+  }
+}
+
+export const getDummyDeploymentContext = (): DeploymentContext => {
+  return {
+    throwError: sinon.fake(),
+    handleError: sinon.fake(),
+    handleAlreadyExecutedDeployment: sinon.fake(),
+    handleExecutionFailure: sinon.fake(),
+    handleSuccess: sinon.fake(),
+    executeTransaction: sinon.fake(),
+    injectRoles: sinon.fake(),
+    removeRoles: sinon.fake(),
+    deployment: getDummyDeployment(),
+    provider: new SphinxJsonRpcProvider(``),
+    wallet: new ethers.Wallet(
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+    ),
+  }
+}
+
+export const getDummyDeployment = (): Deployment => {
+  return {
+    id: 'dummyId',
+    multichainDeploymentId: 'dummyMultichainId',
+    projectId: 'dummyProjectId',
+    chainId: '1',
+    status: 'approved',
+    safeAddress: '0xdummySafeAddress',
+    moduleAddress: '0xdummyModuleAddress',
+    deploymentConfig: getDummyDeploymentConfig(),
+    networkName: 'dummyNetwork',
+    treeSigners: [],
   }
 }

--- a/packages/plugins/test/mocha/fake.ts
+++ b/packages/plugins/test/mocha/fake.ts
@@ -5,7 +5,11 @@ import {
   DeploymentConfig,
   SphinxTransactionReceipt,
 } from '@sphinx-labs/core'
-import { Operation, SphinxModuleABI } from '@sphinx-labs/contracts'
+import {
+  ContractArtifact,
+  Operation,
+  SphinxModuleABI,
+} from '@sphinx-labs/contracts'
 import { EventFragment, ethers } from 'ethers'
 
 import {
@@ -58,6 +62,20 @@ export const getFakeConfigArtifacts = async (
       artifactFolder
     )
     configArtifacts[name] = {
+      buildInfoId: dummyBuildInfoId,
+      artifact,
+    }
+  }
+  return configArtifacts
+}
+
+export const getFakeConfigArtifactsFromContractArtifacts = async (
+  artifacts: Array<ContractArtifact>
+): Promise<ConfigArtifacts> => {
+  const configArtifacts: ConfigArtifacts = {}
+  for (const artifact of artifacts) {
+    const fullyQualifiedName = `${artifact.sourceName}:${artifact.contractName}`
+    configArtifacts[fullyQualifiedName] = {
       buildInfoId: dummyBuildInfoId,
       artifact,
     }

--- a/packages/plugins/test/mocha/simulate.spec.ts
+++ b/packages/plugins/test/mocha/simulate.spec.ts
@@ -9,9 +9,13 @@ import {
   isFork,
   isLiveNetwork,
   NetworkConfig,
+  InvariantError,
+  sphinxCoreExecute,
 } from '@sphinx-labs/core'
 import { ethers } from 'ethers'
 import { SPHINX_NETWORKS } from '@sphinx-labs/contracts'
+import sinon from 'sinon'
+import { HardhatEthersProvider } from '@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider'
 
 import {
   getAnvilRpcUrl,
@@ -21,7 +25,17 @@ import {
   makeStandardDeployment,
   startForkedAnvilNodes,
 } from './common'
-import { simulate } from '../../src/hardhat/simulate'
+import {
+  getUndeployedContractErrorMesage,
+  handleSimulationSuccess,
+  simulate,
+  simulateDeploymentSubtask,
+} from '../../src/hardhat/simulate'
+import {
+  dummyUnlabeledAddress,
+  getDummyDeploymentConfig,
+  getDummyNetworkConfig,
+} from './dummy'
 
 chai.use(chaiAsPromised)
 
@@ -143,5 +157,71 @@ describe('Simulate', () => {
     )
 
     await killAnvilNodes([ethereumChainId])
+  })
+})
+
+describe('simulateDeploymentSubtask', () => {
+  const testInvariantErrorMessage = 'Test InvariantError'
+  const hre: any = {}
+  hre.ethers = {}
+
+  let providerStub: sinon.SinonStubbedInstance<HardhatEthersProvider>
+
+  beforeEach(() => {
+    providerStub = sinon.createStubInstance(HardhatEthersProvider)
+    hre.ethers.provider = providerStub
+
+    sinon
+      .stub(sphinxCoreExecute, 'compileAndExecuteDeployment')
+      .throws(new InvariantError(testInvariantErrorMessage))
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should rethrow the InvariantError thrown by compileAndExecuteDeployment', async () => {
+    const taskArgs = {
+      deploymentConfig: getDummyDeploymentConfig(),
+      chainId: '1',
+    }
+
+    try {
+      await simulateDeploymentSubtask(taskArgs, hre)
+      // If the function doesn't throw, force the test to fail
+      expect.fail('Expected function to throw an InvariantError.')
+    } catch (error) {
+      expect(error).to.be.instanceOf(InvariantError)
+      expect(error.message).to.include(testInvariantErrorMessage)
+    }
+  })
+})
+
+describe('handleSimulationSuccess', () => {
+  let providerStub: sinon.SinonStubbedInstance<HardhatEthersProvider>
+
+  beforeEach(() => {
+    providerStub = sinon.createStubInstance(HardhatEthersProvider)
+
+    providerStub.getCode.resolves('0x')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should throw an InvariantError if a contract address has no deployed code', async () => {
+    const networkConfig = getDummyNetworkConfig()
+
+    try {
+      await handleSimulationSuccess(networkConfig, providerStub)
+      // If the function doesn't throw, force the test to fail
+      expect.fail('Expected function to throw an InvariantError.')
+    } catch (error) {
+      expect(error).to.be.instanceOf(InvariantError)
+      expect(error.message).to.include(
+        getUndeployedContractErrorMesage(dummyUnlabeledAddress)
+      )
+    }
   })
 })


### PR DESCRIPTION
Adds logic that would have caught the error in this ticket: [Contract addresses not properly calculated for new keyword](https://linear.app/chugsplash/issue/CHU-659/contract-addresses-not-properly-calculated-for-new-keyword). Specifically, we now check that all of the contracts in the NetworkConfig have been deployed at the end of the simulation. I also updated an integration test in `deploy.spec.ts` to deploy the same project twice, which would have caused this error if we were still using `FOUNDRY_SENDER`.

Notes:
* This PR doesn't fix the `FOUNDRY_SENDER` error in Foundry. We created [this ticket](https://linear.app/chugsplash/issue/CHU-681/fix-foundry-sender-bug-in-foundrys-codebase) to fix it in Foundry.
* We'll add `FOUNDRY_SENDER` back to our logic when we support linked libraries. ([Here's the relevant ticket for supporting linked libraries](https://linear.app/chugsplash/issue/CHU-297/support-linked-libraries))