### PR TITLE
fix(ct): Detect missing depth field

### DIFF
--- a/.changeset/famous-readers-jam.md
+++ b/.changeset/famous-readers-jam.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/contracts': patch
+---
+
+Detect missing depth field in account accesses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,10 @@ jobs:
           username: samgoldman
           password: $DOCKERHUB_PASSWORD
     steps:
-      - restore_cache:
-          keys:
-            - v2-cache-source-{{ .Branch }}-{{ .Revision }}
-            - v2-cache-source-{{ .Branch }}
+      # - restore_cache:
+      #     keys:
+      #       - v2-cache-source-{{ .Branch }}-{{ .Revision }}
+      #       - v2-cache-source-{{ .Branch }}
       - checkout
       - save_cache:
           key: v2-cache-source-{{ .Branch }}-{{ .Revision }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/contracts/lib/forge-std"]
-	path = packages/contracts/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/packages/contracts/contracts/foundry/SphinxUtils.sol
+++ b/packages/contracts/contracts/foundry/SphinxUtils.sol
@@ -91,6 +91,12 @@ contract SphinxUtils is SphinxConstants, StdUtils {
             return false;
         }
 
+        // If the second access has a depth of 0, then the foundry version installed must not include
+        // the depth field, so we return false
+        if (accountAccesses[1].depth == 0) {
+            return false;
+        }
+
         // If the deployed code at the calculated address is incorrect, then return false.
         // This confirms the deterministic deployment proxy is in fact being used for the
         // internal simulation.

--- a/packages/contracts/test/SphinxUtils.t.sol
+++ b/packages/contracts/test/SphinxUtils.t.sol
@@ -22,7 +22,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
 
     function setUp() public {}
 
-    function test_checkFork_passes() external {
+    function test_checkAccesses_passes() external {
         vm.startStateDiffRecording();
         new SphinxForkCheck{ salt: 0 }();
         Vm.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
@@ -61,7 +61,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 2
+            depth: 0
         });
         accountAccesses[1] = VmSafe.AccountAccess({
             chainInfo: VmSafe.ChainInfo(0, 1),
@@ -76,7 +76,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 3
+            depth: 1
         });
 
         bool passedCheck = checkAccesses(
@@ -108,7 +108,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 2
+            depth: 0
         });
         accountAccesses[1] = VmSafe.AccountAccess({
             chainInfo: VmSafe.ChainInfo(0, 1),
@@ -127,7 +127,54 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 3
+            depth: 1
+        });
+
+        bool passedCheck = checkAccesses(
+            accountAccesses,
+            keccak256(type(SphinxForkCheck).creationCode),
+            keccak256(type(SphinxForkCheck).runtimeCode)
+        );
+        assertEq(passedCheck, false);
+    }
+
+    function test_sphinxCheckAccesses_fails_incorrect_depth() external {
+        address expectedAddress = vm.computeCreate2Address(
+            0,
+            keccak256(type(SphinxForkCheck).creationCode),
+            DETERMINISTIC_DEPLOYMENT_PROXY
+        );
+
+        Vm.AccountAccess[] memory accountAccesses = new Vm.AccountAccess[](2);
+        accountAccesses[0] = VmSafe.AccountAccess({
+            chainInfo: VmSafe.ChainInfo(0, 1),
+            kind: VmSafe.AccountAccessKind.Call,
+            account: address(DETERMINISTIC_DEPLOYMENT_PROXY),
+            accessor: address(this),
+            initialized: false,
+            oldBalance: 0,
+            newBalance: 0,
+            deployedCode: new bytes(0),
+            value: 0,
+            data: type(SphinxForkCheck).creationCode,
+            reverted: false,
+            storageAccesses: new Vm.StorageAccess[](0),
+            depth: 0
+        });
+        accountAccesses[1] = VmSafe.AccountAccess({
+            chainInfo: VmSafe.ChainInfo(0, 1),
+            kind: VmSafe.AccountAccessKind.Create,
+            account: address(expectedAddress),
+            accessor: DETERMINISTIC_DEPLOYMENT_PROXY,
+            initialized: false,
+            oldBalance: 0,
+            newBalance: 0,
+            deployedCode: "",
+            value: 0,
+            data: type(SphinxForkCheck).creationCode,
+            reverted: false,
+            storageAccesses: new Vm.StorageAccess[](0),
+            depth: 0
         });
 
         bool passedCheck = checkAccesses(
@@ -153,7 +200,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 2
+            depth: 0
         });
         accountAccesses[1] = VmSafe.AccountAccess({
             chainInfo: VmSafe.ChainInfo(0, 1),
@@ -171,7 +218,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 3
+            depth: 1
         });
 
         bool passedCheck = checkAccesses(
@@ -197,7 +244,7 @@ contract SphinxUtils_Test is Test, SphinxUtils {
             data: type(SphinxForkCheck).creationCode,
             reverted: false,
             storageAccesses: new Vm.StorageAccess[](0),
-            depth: 2
+            depth: 0
         });
 
         bool passedCheck = checkAccesses(


### PR DESCRIPTION
## Purpose
Adds logic to the foundry version validation process to detect if the `depth` field is not included.