### PR TITLE
fix(ct): filter calls to SphinxUtils out of state diff

### DIFF
--- a/.changeset/purple-crews-punch.md
+++ b/.changeset/purple-crews-punch.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+---
+
+Filter calls to SphinxUtils out of state diff

--- a/packages/contracts/contracts/foundry/SphinxUtils.sol
+++ b/packages/contracts/contracts/foundry/SphinxUtils.sol
@@ -849,7 +849,7 @@ contract SphinxUtils is SphinxConstants, StdUtils {
     function getNumRootAccountAccesses(
         Vm.AccountAccess[] memory _accesses,
         address _safeAddress
-    ) private pure returns (uint256) {
+    ) private view returns (uint256) {
         uint256 count = 0;
         for (uint256 i = 0; i < _accesses.length; i++) {
             Vm.AccountAccess memory access = _accesses[i];
@@ -874,14 +874,17 @@ contract SphinxUtils is SphinxConstants, StdUtils {
      * - The call depth is equal to 2. The expected depth is 2 because the depth value starts
      * at 1 and because we initiate the collection process by doing a delegatecall to the entry
      * point function so the depth is 2 by the time any transactions get sent in the users script.
+     * - The target contract is not `SphinxUtils`. This can occur if the user calls a function
+     * that calls into this contract during their script. I.e calling safeAddress().
      */
     function isRootAccountAccess(
         Vm.AccountAccess memory _access,
         address _safeAddress
-    ) private pure returns (bool) {
+    ) private view returns (bool) {
         return
             _access.accessor == _safeAddress &&
             _access.depth == 2 &&
+            _access.account != address(this) &&
             (_access.kind == VmSafe.AccountAccessKind.Call ||
                 _access.kind == VmSafe.AccountAccessKind.Create);
     }
@@ -890,7 +893,7 @@ contract SphinxUtils is SphinxConstants, StdUtils {
         Vm.AccountAccess[] memory _accesses,
         uint256 _rootIdx,
         address _safeAddress
-    ) private pure returns (uint256) {
+    ) private view returns (uint256) {
         uint256 count = 0;
         for (uint256 i = _rootIdx + 1; i < _accesses.length; i++) {
             Vm.AccountAccess memory access = _accesses[i];
@@ -1061,7 +1064,7 @@ contract SphinxUtils is SphinxConstants, StdUtils {
     function parseAccountAccesses(
         Vm.AccountAccess[] memory _accesses,
         address _safeAddress
-    ) public pure returns (ParsedAccountAccess[] memory) {
+    ) public view returns (ParsedAccountAccess[] memory) {
         uint256 numRoots = getNumRootAccountAccesses(_accesses, _safeAddress);
 
         ParsedAccountAccess[] memory parsed = new ParsedAccountAccess[](numRoots);

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 src = 'contracts'
-fs_permissions = [{ access = "read", path = "./"}]
+fs_permissions = [{ access = "read-write", path = "./"}]
 verbosity = 2
 ffi = true
 solc = '0.8.4'

--- a/packages/plugins/contracts/test/script/issues/CHU676.s.sol
+++ b/packages/plugins/contracts/test/script/issues/CHU676.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Script } from "sphinx-forge-std/Script.sol";
+import { Network } from "@sphinx-labs/contracts/contracts/foundry/SphinxPluginTypes.sol";
+import { Sphinx } from "@sphinx-labs/contracts/contracts/foundry/Sphinx.sol";
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+import { Owned } from "./Owned.sol";
+
+contract CHU676 is Sphinx {
+    function configureSphinx() public override {
+        sphinxConfig.projectName = "CHU-676";
+        sphinxConfig.owners = [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266];
+        sphinxConfig.threshold = 1;
+        sphinxConfig.orgId = "test-org-id";
+    }
+
+    function run() public sphinx {
+        address module = sphinxModule();
+        new Owned{ salt: 0 }(module);
+    }
+}
+

--- a/packages/plugins/contracts/test/script/issues/Owned.sol
+++ b/packages/plugins/contracts/test/script/issues/Owned.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Owned {
+    address public owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes an issue where calls to the SphinxUtils contract could be included in the deployment if they happened during the user script. I.e if the user called `safeAddress()`, then the call to SphinxUtils to fetch the address would have been included. 