### PR TITLE
fix(ct): Prevent infinite loop in configureSphinx function

### DIFF
--- a/.changeset/purple-jars-knock.md
+++ b/.changeset/purple-jars-knock.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/contracts': patch
+---
+
+Stop infinite loop if the user calls safeAddress() in configureSphinx() function

--- a/packages/contracts/test/issues/CHU663/CHU663.s.sol
+++ b/packages/contracts/test/issues/CHU663/CHU663.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../../contracts/forge-std/src/Script.sol";
+import "../../../contracts/forge-std/src/Test.sol";
+import { Sphinx } from "../../../contracts/foundry/Sphinx.sol";
+
+contract CHU663_test is Test, Sphinx {
+    address public safe;
+
+    function configureSphinx() public override {
+        sphinxConfig.projectName = "CHU-663";
+        sphinxConfig.owners = [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266];
+        sphinxConfig.threshold = 1;
+        sphinxConfig.orgId = "test-org-id";
+        safe = safeAddress();
+    }
+
+    function test_configureSphinx_success_calls_safeAddress() external {
+        configureSphinx();
+        assertNotEq(safe, address(0));
+    }
+}


### PR DESCRIPTION
## Purpose
Resolves an infinite loop that can occur if the user calls `safeAddress()` or some other function that requires the `sphinxConfig` from within their `configureSphinx()` function.