### PR TITLE
maint(ct): Remove submodules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,7 @@ jobs:
           keys:
             - v2-cache-source-{{ .Branch }}-{{ .Revision }}
             - v2-cache-source-{{ .Branch }}
-      - run:
-          name: Reset Head
-          command: git reset --hard || true
       - checkout
-      - run:
-          name: Initialize submodules
-          command: |
-            git submodule init
-            git submodule update
       - save_cache:
           key: v2-cache-source-{{ .Branch }}-{{ .Revision }}
           paths:


### PR DESCRIPTION
## Purpose
Removes the use of submodules in our project including steps to handle their installation in the CI process. We can do this b/c #1530 removed the installation of `forge-std` in favor of having all of the files stored locally within the repo. 