### PR TITLE
fix(pg): Fetch artifacts via presigned url

### DIFF
--- a/.changeset/nice-guests-camp.md
+++ b/.changeset/nice-guests-camp.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Fetch artifacts via presigned url

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -64,6 +64,7 @@ export const fetchDeploymentArtifacts = async (
       apiKey,
       orgId,
       projectName,
+      viaPresignedUrl: true,
     })
     .catch((err) => {
       if (err.response) {
@@ -87,7 +88,8 @@ export const fetchDeploymentArtifacts = async (
       }
     })
 
-  return response.data
+  const artifact = await axios.get(response.data)
+  return artifact.data as DeploymentArtifacts
 }
 
 /**


### PR DESCRIPTION
## Purpose
Updates artifact fetch request to get a pre-signed URL and then download the artifacts directly from S3. This allows for arbitrarily large artifact files and resolves [CHU-675](https://linear.app/chugsplash/issue/CHU-675/fix-the-error-that-0xbased-ran-into-when-fetching-deployment-artifacts).