### PR TITLE
fix(core): Suggest rebuilding with --force if we fail to infer a contract artifact

### DIFF
--- a/.changeset/short-doors-beg.md
+++ b/.changeset/short-doors-beg.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Suggest running forge build with --force if we fail to infer artifact

--- a/packages/core/src/preview.ts
+++ b/packages/core/src/preview.ts
@@ -146,7 +146,8 @@ export const getPreviewString = (
     previewString += yellow(
       `This typically happens when deploying contracts using hardcoded bytecode and no \n` +
         `associated source file. Sphinx will not create a deployment artifact or attempt \n` +
-        `Etherscan verification for any address in the list above.\n\n`
+        `Etherscan verification for any address in the list above.\n\n` +
+        `If you think this is a mistake, try running "forge build --force", then run your Sphinx command again.\n`
     )
   }
 


### PR DESCRIPTION
## Purpose
A temporary solution to the bug where we fail to properly infer a contract artifact where we simply suggest running `forge build --force` if the user thinks we made a mistake.