### PR TITLE
fix(pg): Throw an error if the simulation is going to fail due to a missing hardhat config

### DIFF
--- a/.changeset/sixty-worms-agree.md
+++ b/.changeset/sixty-worms-agree.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Throw an error if the simulation is going to fail due to missing hardhat config

--- a/packages/plugins/src/hardhat/simulate.ts
+++ b/packages/plugins/src/hardhat/simulate.ts
@@ -1,4 +1,5 @@
 import { join } from 'path'
+import { existsSync } from 'fs'
 
 import {
   spawnAsync,
@@ -84,13 +85,25 @@ export const simulate = async (
     deploymentConfig
   )
 
+  const expectedHardhatConfigPath = join(
+    rootPluginPath,
+    'dist',
+    'hardhat.config.js'
+  )
+
+  if (!existsSync(expectedHardhatConfigPath)) {
+    throw new Error(
+      'Failed to locate simulation configuration. This is a bug, please report it to the developers'
+    )
+  }
+
   const envVars = {
     SPHINX_INTERNAL__FORK_URL: rpcUrl,
     SPHINX_INTERNAL__CHAIN_ID: chainId,
     SPHINX_INTERNAL__BLOCK_GAS_LIMIT: networkConfig.blockGasLimit,
     // We must set the Hardhat config using an environment variable so that Hardhat recognizes the
     // Hardhat config when we import the HRE in the child process.
-    HARDHAT_CONFIG: join(rootPluginPath, 'dist', 'hardhat.config.js'),
+    HARDHAT_CONFIG: expectedHardhatConfigPath,
   }
 
   const taskParams: simulateDeploymentSubtaskArgs = {


### PR DESCRIPTION
## Purpose
Adds logic to detect if the hardhat config we use for the simulation is not in the expected location. This can occur if the user's package manager is configured to store dependency files in non-standard locations. I've confirmed this is not an issue with PNPM, but I believe it would be an issue with some yarn configurations (especially yarn versions 2 and 3). 

I was not able to come up with a good true solution for this which is why this PR just adds logic to throw a better error message. I believe the ideal solution is to switch to using a precompiled NodeJS binary for installation, which would not be subject to this issue. 