### PR TITLE
fix(pg): Conform to standard JSON format for getaddrinfo error

### DIFF
--- a/.changeset/long-chairs-hunt.md
+++ b/.changeset/long-chairs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Passthrough getaddrinfo error using standard json format

--- a/packages/plugins/src/hardhat/hardhatRunner.ts
+++ b/packages/plugins/src/hardhat/hardhatRunner.ts
@@ -51,18 +51,17 @@ process.on('uncaughtException', (error) => {
    * It's worth mentioning, that we've already had logic that handles this running in the website backend
    * and it very reliably works for handling this exact issue.
    */
-  if (error.message.includes('getaddrinfo ENOTFOUND')) {
-    if (getaddrinfoErrors < 25) {
-      getaddrinfoErrors += 1
-      return
-    } else {
-      throw error
-    }
+  if (
+    error.message.includes('getaddrinfo ENOTFOUND') &&
+    getaddrinfoErrors < 25
+  ) {
+    getaddrinfoErrors += 1
+    return
+  } else {
+    process.stdout.write(
+      JSON.stringify({ message: error.message, stack: error.stack })
+    )
+
+    process.exit(1)
   }
-
-  process.stdout.write(
-    JSON.stringify({ message: error.message, stack: error.stack })
-  )
-
-  process.exit(1)
 })


### PR DESCRIPTION
## Purpose
I added logic to pass through the getaddrinfo error if it occurs many times during the simulation. This PR updates that logic to follow the pattern of passing up errors using JSON objects.