### PR TITLE
fix(pg): update build info cache to include fields for deployed bytecode exact match

### DIFF
--- a/.changeset/tricky-points-heal.md
+++ b/.changeset/tricky-points-heal.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Update build info cache to include fields for deployed bytecode exact match

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -96,6 +96,10 @@ export type LinkReferences = {
   }
 }
 
+export type ImmutableReferences = {
+  [key: string]: Array<{ start: number; length: number }>
+}
+
 export type ContractArtifact = {
   abi: Array<any>
   sourceName: string
@@ -105,6 +109,7 @@ export type ContractArtifact = {
   linkReferences: LinkReferences
   deployedLinkReferences: LinkReferences
   metadata: CompilerOutputMetadata
+  immutableReferences: ImmutableReferences
   storageLayout?: SolidityStorageLayout
   methodIdentifiers?: {
     [methodSignature: string]: string

--- a/packages/core/src/actions/execute.ts
+++ b/packages/core/src/actions/execute.ts
@@ -1244,7 +1244,7 @@ export const compileAndExecuteDeployment = async (
     }
   }
 
-  deploymentContext.spinner?.start('Execution ready')
+  deploymentContext.spinner?.succeed('Execution ready')
 
   if (deployment.status === 'approved') {
     let receipts: ethers.TransactionReceipt[] = []

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import { promisify } from 'util'
 import { exec, spawn } from 'child_process'
 import { join } from 'path'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 
 import yesno from 'yesno'
 import axios from 'axios'
@@ -1654,3 +1654,5 @@ export const hasParentheses = (str: string): boolean => {
 export const trimQuotes = (str: string): string => {
   return str.replace(/^['"]+|['"]+$/g, '')
 }
+
+export const sphinxCoreUtils = { readFileSync, existsSync }

--- a/packages/plugins/src/foundry/types.ts
+++ b/packages/plugins/src/foundry/types.ts
@@ -1,7 +1,9 @@
+import { ImmutableReferences, LinkReferences } from '@sphinx-labs/contracts'
 import {
   FoundryBroadcastTransaction,
   FoundryDryRunTransaction,
 } from '@sphinx-labs/core'
+import { ethers } from 'ethers'
 
 export type FoundryTransactionReceipt = {
   transactionHash: string
@@ -73,4 +75,28 @@ export type FoundryToml = {
       key: string
     }
   }
+}
+
+export type BuildInfoCache = {
+  _format: 'sphinx-build-info-cache-1'
+  entries: Record<string, BuildInfoCacheEntry>
+}
+
+/**
+ * @field contracts An array where each element corresponds to a contract in the
+ * `BuildInfo.output.contracts` object. We use this array to match collected contract init code and
+ * runtime bytecode to the corresponding artifact.
+ */
+export type BuildInfoCacheEntry = {
+  name: string
+  time: number
+  contracts: Array<{
+    fullyQualifiedName: string
+    bytecode: string
+    deployedBytecode: string
+    linkReferences: LinkReferences
+    deployedLinkReferences: LinkReferences
+    immutableReferences: ImmutableReferences
+    constructorFragment?: ethers.ConstructorFragment
+  }>
 }

--- a/packages/plugins/src/hardhat/simulate.ts
+++ b/packages/plugins/src/hardhat/simulate.ts
@@ -67,6 +67,11 @@ export type simulateDeploymentSubtaskArgs = {
  * `spawn` is prone to input size limits, and EthersJS can't ABI encode extremely large amounts
  * of data (i.e. it'll fail for a Merkle tree that contains 250 contract deployments, where the
  * contract is near the maximum size limit).
+ *
+ * It's important to use a simulation to check that the Merkle leaf gas fields are sufficiently high.
+ * If a Merkle leaf gas field is too low, the simulation will fail because the associated `EXECUTE`
+ * action should fail in the simulation. The simulation must fork the corresponding live network
+ * because the user's transactions may interact with contracts that already exist on-chain.
  */
 export const simulate = async (
   deploymentConfig: DeploymentConfig,

--- a/packages/plugins/test/mocha/dummy.ts
+++ b/packages/plugins/test/mocha/dummy.ts
@@ -16,6 +16,7 @@ import {
 import { ethers } from 'ethers'
 
 import { makeAddress } from './common'
+import { BuildInfoCache } from '../../src/foundry/types'
 
 export const dummyChainId = '43211234'
 export const dummyMerkleRoot = '0x' + 'fe'.repeat(32)
@@ -283,5 +284,12 @@ export const getDummyDeploymentArtifacts = (): DeploymentArtifacts => {
         solcVersion,
       },
     },
+  }
+}
+
+export const getDummyBuildInfoCache = (): BuildInfoCache => {
+  return {
+    _format: 'sphinx-build-info-cache-1',
+    entries: {},
   }
 }


### PR DESCRIPTION
Updates the build info cache to include deployed bytecode and other relevant fields, which are necessary to implement option 4 in this ticket: [Improve error message when user calls a non-existent function on their script](https://linear.app/chugsplash/issue/CHU-655/improve-error-message-when-user-calls-a-non-existent-function-on-their). Option 4 requires us to make an exact bytecode match on the script's deployed bytecode, but before this PR, it was only possible to check for an exact match on the _init code_ because we didn't store the deployed bytecode in the build info cache.

I added a `_format` field to the build info cache to signify that its structure has changed. I also added logic that handles outdated build info caches for backwards compatibility.

Note: The `findFullyQualifiedNames` function is currently causing the plugins and demo test suite to fail in CI. I'm planning on removing this function in the next PR, so just disregard the failed tests.