### PR TITLE
feat(pg): Supply more cost estimate data in proposal request

### DIFF
--- a/.changeset/clean-dogs-poke.md
+++ b/.changeset/clean-dogs-poke.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Include specific transaction data in NetworkGasEstimates

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -106,10 +106,52 @@ export type ContractInfo = {
   addr: string
 }
 
+export type EstimateGasTransactionData = {
+  to: string | null
+  from: string
+  data: string
+  gasLimit: string
+  gasPrice: string
+  value: string
+  chainId: string
+}
+
+/**
+ * The estimated cost for a specific transaction during a deployment.
+ *
+ * @property {object} transaction: The raw transaction data. This is useful for networks that have custom RPC methods for
+ * calculating fees such as polygon zkevm.
+ * @property {string} estimatedGas: The amount of gas we estimate will be used by this transaction.
+ *
+ */
+export type TransactionEstimatedGas = {
+  transaction: EstimateGasTransactionData
+  estimatedGas: string
+}
+
+/**
+ * The estimated cost to execute the deployment on a given network. Includes the overall gas cost with a buffer as well
+ * as the raw transaction data used to generate the estimate. We include the transaction data because some networks have
+ * more complex fee formulas or custom RPC methods for calculating fees which require more information.
+ *
+ * Note that the array of transactions contains approximately the transactions we will actually use when executing the
+ * deployment and *not* the transactions defined by the user. So this array will contain a transaction to approve the deployment
+ * and a series of transactions to execute batches of actions via the users module. The real transactions we end up executing
+ * may end up being somewhat different depending on network conditions.
+ *
+ * @property {number} chainId: The id of the network this estimate is for.
+ * @property {string} estimatedGas: The amount of gas we've estimated will be used for the entire deployment including a buffer.
+ * @property {array} transactions: An array of individual transactions used to generate this estimate along with their estimated
+ * gas cost and estimated blob gas cost.
+ */
+export type NetworkGasEstimate = {
+  chainId: number
+  estimatedGas: string
+  transactions: Array<TransactionEstimatedGas>
+}
+
 /**
  * @param compilerConfigId Deprecated field.
- * @param gasEstimates The estimated amount of gas required to the entire deployment tree on each
- * chain, including a buffer.
  */
 export type ProposalRequest = {
   apiKey: string
@@ -124,7 +166,7 @@ export type ProposalRequest = {
   deploymentName: string
   chainIds: Array<number>
   projectDeployments: Array<ProjectDeployment>
-  gasEstimates: Array<{ chainId: number; estimatedGas: string }>
+  gasEstimates: Array<NetworkGasEstimate>
   diff: SphinxPreview
   compilerConfigId: string | undefined
   deploymentConfigId: string | undefined

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -65,7 +65,8 @@
     "typescript": "^5.1.3",
     "yargs": "^17.7.2",
     "yesno": "^0.4.0",
-    "hardhat": "2.20.1"
+    "hardhat": "2.20.1",
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "@layerzerolabs/solidity-examples": "^0.0.13",

--- a/packages/plugins/src/cli/types.ts
+++ b/packages/plugins/src/cli/types.ts
@@ -6,6 +6,7 @@ import {
   GetConfigArtifacts,
   NetworkConfig,
   BuildInfos,
+  NetworkGasEstimate,
 } from '@sphinx-labs/core'
 
 import { FoundryToml } from '../foundry/types'
@@ -47,10 +48,7 @@ export type GetNetworkGasEstimate = (
   deploymentConfig: DeploymentConfig,
   chainId: string,
   rpcUrl: string
-) => Promise<{
-  chainId: number
-  estimatedGas: string
-}>
+) => Promise<NetworkGasEstimate>
 
 export type BuildNetworkConfigArray = (
   scriptPath: string,

--- a/packages/plugins/src/hardhat/hardhatRunner.ts
+++ b/packages/plugins/src/hardhat/hardhatRunner.ts
@@ -25,10 +25,14 @@ process.stdin.on('end', async () => {
 const runHardhatSimulation = async (
   taskArgs: simulateDeploymentSubtaskArgs
 ): Promise<void> => {
-  const { receipts }: Awaited<ReturnType<typeof simulateDeploymentSubtask>> =
-    await hre.run('sphinxSimulateDeployment', taskArgs)
+  const {
+    transactions,
+  }: Awaited<ReturnType<typeof simulateDeploymentSubtask>> = await hre.run(
+    'sphinxSimulateDeployment',
+    taskArgs
+  )
 
-  process.stdout.write(JSON.stringify({ receipts }))
+  process.stdout.write(JSON.stringify({ transactions }))
 }
 
 let getaddrinfoErrors = 0

--- a/packages/plugins/test/mocha/mock.ts
+++ b/packages/plugins/test/mocha/mock.ts
@@ -33,6 +33,7 @@ export const makeMockSphinxContext = (
       Promise.resolve({
         chainId: 0,
         estimatedGas: '0',
+        transactions: [],
       })
     )
   const relayProposal = sinon


### PR DESCRIPTION
## Purpose
This PR adds additional gas estimate-related data to the ProposalRequest object. This data gives us more flexibility to implement different logic for calculating deployment costs for different networks with different fee formulas or custom RPC methods for calculating fees. 

Note that this PR does not resolve any known cases where we do not accurately estimate deployment costs (optimism, blast, polygon zkevm). I think the best option for handling those cases is to provide more information to the website's backend and then implement the necessary cost calculation logic on the website instead of within the plugin. The main reason why I think this is better is b/c we know of at least one case where a custom RPC method is required to calculate the cost estimates (polygon zkevm) properly. The RPC method is optional for node providers (like other trace or debug methods), so we can't guarantee the user's provider will include it. 