### PR TITLE
fix(core): Always attempt to verify contracts on Etherscan even if API says it is verified

### DIFF
--- a/.changeset/clean-chairs-mate.md
+++ b/.changeset/clean-chairs-mate.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Always attempt to verify contract even if Etherscan claims it is verified


### PR DESCRIPTION
## Purpose
Fixes an issue where contracts occasionally fail to be verified on Etherscan when deploying via the DevOps platform. The problem was occurring because sometimes the isVerified function would return true even if the contract wasn't displaying as verified in the Etherscan UI. 

I wasn't originally planning to do this but I've started to notice this issue pretty regularly, especially when running through the quickstart, so I decided to spend a little bit of time investigating it.

Specifically, this issue can happen if the contract is verified implicitly by Etherscan using their internal source code database and not by us calling their API. What seems to be happening is: 
1. We deploy the contract
2. Etherscan indexes the contract and links it to the source code of another already verified contract (but for some reason, this does not show up in the UI even after a long period)
3. When we attempt to verify the contract, our logic first calls their API to check if it is verified via the `isVerified` function. This returns true because the Etherscan API does return the source code for the contract even though it is not showing up in the UI. As a result, we skip attempting to verify the contract.

Unfortunately, this appears to be a bug on Etherscan's side mainly. For some reason, their internal source code linking sometimes results in the source code not actually showing up in their UI. There's nothing we can directly do to resolve that. However, I found that simply attempting to verify the contract, even though it's already verified, resolves the issue and the contract appears in the UI. This seems like a perfectly acceptable workaround to me.

So in this PR, I've updated the verification logic so we always attempt to verify the contract. If an error occurs during verification, then we check if the contract is already verified (Etherscan's API throws an error if you attempt to verify a contract that is already verified) and return successfully if so. I found this to be able to reliably verify contracts on Etherscan including ones that were implicitly verified through Etherscan's source code linking.