### PR TITLE
fix(pg): Avoid recompiling every single time we invoke the users script

### DIFF
--- a/.changeset/moody-trees-sing.md
+++ b/.changeset/moody-trees-sing.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Avoid recompiling every single time we invoke the users script

--- a/docs/cli-existing-project.md
+++ b/docs/cli-existing-project.md
@@ -189,7 +189,6 @@ ALCHEMY_API_KEY=<your_api_key>
 Update your `foundry.toml` file to include a few settings required by Sphinx. We recommend putting them in `[profile.default]`.
 
 ```
-build_info = true
 extra_output = ['storageLayout']
 fs_permissions = [{ access = "read-write", path = "./"}]
 ```

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -136,6 +136,10 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
       // priority than `DAPP_BLOCK_GAS_LIMIT`.
       FOUNDRY_BLOCK_GAS_LIMIT: MAX_UINT64.toString(),
       ETH_FROM: safeAddress,
+      // We specify build info to be false so that calling the script does not cause the users entire
+      // project to be rebuilt if they have `build_info=true` defined in their foundry.toml file.
+      // We do need the build info, but that is generated when we compile at the beginning of the script.
+      FOUNDRY_BUILD_INFO: 'false',
     })
 
     if (spawnOutput.code !== 0) {
@@ -246,10 +250,23 @@ export const propose = async (
     process.exit(1)
   }
 
-  // Run the compiler. It's necessary to do this before we read any contract interfaces.
+  /**
+   * Run the compiler. It's necessary to do this before we read any contract interfaces.
+   * We force recompile and request the build info here. We need to build info to generate
+   * the compiler config.
+   *
+   * The current behavior of Foundry is to disregard the cache when compiling with the build info.
+   * This causes the users entire project to be rebuilt when the build info file is requested. So
+   * since we have to rebuild the entire project anyway, we also use force which will remove any
+   * previous build info files making our later logic for reading the build info files more performant.
+   *
+   * If/when Foundry fixes this so that the cache is used when the build info file is requested, we should
+   * remove force here for the best performance.
+   */
   compile(
     silent,
-    false // Do not force re-compile.
+    true, // Force recompile
+    true // Generate build info
   )
 
   const scriptFunctionCalldata = await parseScriptFunctionCalldata(sig)

--- a/packages/plugins/src/foundry/options.ts
+++ b/packages/plugins/src/foundry/options.ts
@@ -25,12 +25,6 @@ export const resolvePaths = (outPath: string, buildInfoPath: string) => {
 }
 
 export const checkRequiredTomlOptions = (toml: FoundryToml) => {
-  if (toml.buildInfo !== true) {
-    throw new Error(
-      'Missing required option in foundry.toml file:\nbuild_info = true\nPlease update your foundry.toml file and try again.'
-    )
-  }
-
   // Check if the user included the `storageLayout` option. Since foundry force recompiles after
   // changing the foundry.toml file, we can assume that the contract artifacts will contain the
   // necessary info as long as the config includes the expected options

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -300,7 +300,11 @@ export const getInitCodeWithArgsArray = (
  * It's fine for recompilation to occur after running the user's Forge script because Foundry
  * automatically compiles the necessary contracts before executing it.
  */
-export const compile = (silent: boolean, force: boolean): void => {
+export const compile = (
+  silent: boolean,
+  force: boolean,
+  buildInfo: boolean
+): void => {
   const forgeBuildArgs = ['build']
 
   if (silent) {
@@ -308,6 +312,9 @@ export const compile = (silent: boolean, force: boolean): void => {
   }
   if (force) {
     forgeBuildArgs.push('--force')
+  }
+  if (buildInfo) {
+    forgeBuildArgs.push('--build-info')
   }
 
   // We use `spawnSync` to display the compilation process to the user as it occurs. Compiler errors
@@ -833,7 +840,12 @@ export const callForgeScriptFunction = async <T>(
     code: testCode,
     stdout: testOut,
     stderr: testErr,
-  } = await spawnAsync('forge', testScriptArgs)
+  } = await spawnAsync('forge', testScriptArgs, {
+    // We specify build info to be false so that calling the script does not cause the users entire
+    // project to be rebuilt if they have `build_info=true` defined in their foundry.toml file.
+    // We do need the build info, but that is generated when we compile at the beginning of the script.
+    FOUNDRY_BUILD_INFO: 'false',
+  })
 
   if (testCode !== 0) {
     spinner?.stop()
@@ -855,7 +867,12 @@ export const callForgeScriptFunction = async <T>(
     true
   )
 
-  const { code, stdout, stderr } = await spawnAsync('forge', forgeScriptArgs)
+  const { code, stdout, stderr } = await spawnAsync('forge', forgeScriptArgs, {
+    // We specify build info to be false so that calling the script does not cause the users entire
+    // project to be rebuilt if they have `build_info=true` defined in their foundry.toml file.
+    // We do need the build info, but that is generated when we compile at the beginning of the script.
+    FOUNDRY_BUILD_INFO: 'false',
+  })
 
   // For good measure, we still read the code and error if necessary but this is unlikely to be triggered
   if (code !== 0) {

--- a/packages/plugins/src/sample-project/sample-foundry-config.ts
+++ b/packages/plugins/src/sample-project/sample-foundry-config.ts
@@ -23,7 +23,6 @@ export const fetchForgeConfig = (
 ): string => `[profile.default]
 script = 'script'
 test = 'test'
-build_info = true
 extra_output = ['storageLayout']
 fs_permissions=[{access="read", path="./out"}, {access="read-write", path="./cache"}]
 allow_paths = ["../.."]


### PR DESCRIPTION
## Purpose
Fixes an issue reported by Sablier where the `Validating Networks...` step is taking an extremely long time to run.

## Context
Foundry recently implemented a change where the cache is disregarded if the build info file is requested. This causes a UX issue where if you have build_info = true in your foundry.toml file then the entire project is recompiled every single time you run a script/test/etc. This is obviously a terrible experience. 
https://github.com/foundry-rs/foundry/issues/7379

This causes our plugin to run extremely slow because the users entire project is recompiled every time we call into their script. 

This PR makes the following changes to temporarily address the issue:
1. Remove `build_info = true` from our recommended `foundry.toml` settings 
2. When we call `compile` at the beginning of a script we compile with the `--build-info` flag since the rest of our logic still needs it. Also because we have to recompile the entire project anyway, I've added in the `--force` flag because that makes our later logic to fetch the build info file faster.
3. Whenever we call into the users script in the rest of the plugin, I've added an environment variable `FOUNDRY_BUILD_INFO: 'false'`. This prevents the users entire project from being rebuilt whenever we call into the script if the user has `build_info=true` in their `foundry.toml` file. 

## Note
Obviously, this is not the ideal solution. This PR aims to ensure the plugin continues to be usable in projects where compilation takes a long time, such as Sablier. We should further discuss the ideal solution which may involve implementing logic to use the cache when compiling with `build_info=true` in Foundry if that is reasonable to do. 