### PR TITLE
fix(core): Remove gas price override on Gnosis

### DIFF
--- a/.changeset/slow-rings-compete.md
+++ b/.changeset/slow-rings-compete.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Remove gas limit override on Gnosis

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -238,11 +238,6 @@ export const getGasPriceOverrides = async (
     // On OKC, override nothing b/c it's unnecessary
     case 66:
       return overridden
-    // On Gnosis, set the gas limit artificially high (since ethers does not seem to always estimate it proplerly especially for contract deployments)
-    case 100:
-    case 10200:
-      overridden.gasLimit = (block.gasLimit / BigInt(4)) * BigInt(3)
-      return overridden
     // Default to overriding with maxFeePerGas and maxPriorityFeePerGas
     default:
       if (maxFeePerGas !== null && maxPriorityFeePerGas !== null) {


### PR DESCRIPTION
## Purpose
This removes the gas limit override on Gnosis and its testnet. It seems that the root issue causing eth_estimateGas to be calculated incorrectly is no longer a problem, so I am removing this. 

I also noticed that setting the high gas limit appears to be causing problems with certain RPC providers that impose limits on the maximum allowed fee for transactions. I was seeing this error:
`tx fee (1.79 ether) exceeds the configured cap (1.00 ether)` 

This occurs because the RPC provider is imposing a limit on the maximum fee transactions they are allowing. This is only an issue on Gnosis Chiado because the gas price has [increased to an extreme level for an unclear reason](https://gnosis-chiado.blockscout.com/gas-tracker). I think this could potentially cause issues during execution if the user attempted to execute a large deployment on the network. This PR does not fix the issue entirely, but it does make it possible to execute smaller deployments on the network by removing the fixed gas limit. 

This issue won't occur on Gnosis mainnet [since the gas price is reasonable there](https://gnosisscan.io/gastracker). However, I could see this issue potentially coming up again on a different network. I've created a ticket to [investigate that possibility.](https://linear.app/chugsplash/issue/CHU-804/investigate-handling-rpc-providers-with-configured-tx-fee-cap-that-is) 