### PR TITLE
fix(pg): fix simulation bugs

### DIFF
--- a/.changeset/great-ads-rhyme.md
+++ b/.changeset/great-ads-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Fix simulation bugs

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1667,4 +1667,39 @@ export const trimQuotes = (str: string): string => {
   return str.replace(/^['"]+|['"]+$/g, '')
 }
 
-export const sphinxCoreUtils = { sleep, callWithTimeout }
+/**
+ * Checks if a given property of an object is a public asynchronous method.
+ *
+ * This function iterates over the prototype chain of the object to check if the specified property
+ * is an asynchronous function that is not intended to be private (not starting with '_'). We check
+ * for a leading underscore to determine whether a function is meant to be private because
+ * JavaScript doesn't have a native way to check this. This function stops the search once it
+ * reaches the top of the prototype chain or finds a match.
+ *
+ * @param {any} obj - The object to inspect.
+ * @param {string | symbol} prop - The property name or symbol to check.
+ * @returns {boolean} - `true` if the property is a public asynchronous method, `false` otherwise.
+ */
+export const isPublicAsyncMethod = (
+  obj: any,
+  prop: string | symbol
+): boolean => {
+  let currentObj = obj
+
+  while (currentObj && currentObj !== Object.prototype) {
+    const propValue = currentObj[prop]
+    if (
+      typeof propValue === 'function' &&
+      propValue.constructor.name === 'AsyncFunction' &&
+      typeof prop === 'string' &&
+      !prop.startsWith('_')
+    ) {
+      return true
+    }
+    currentObj = Object.getPrototypeOf(currentObj)
+  }
+
+  return false
+}
+
+export const sphinxCoreUtils = { sleep, callWithTimeout, isPublicAsyncMethod }

--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -1105,8 +1105,13 @@ export const makeActionInputsWithoutGas = (
   return actionInputs
 }
 
-export const sumGeometricSeries = (a: number, r: number, n: number): number =>
-  a * ((1 - Math.pow(r, n)) / (1 - r))
+export const sumEvenNumbers = (start: number, numTerms: number): number => {
+  let sum = 0
+  for (let i = 0; i < numTerms; i++) {
+    sum += start + 2 * i
+  }
+  return sum
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const promiseThatNeverSettles = new Promise(() => {})


### PR DESCRIPTION
This PR fixes several issues in the simulation:
* 0xBased ran into a timeout error in his simulation ([ticket](https://linear.app/chugsplash/issue/CHU-805/increase-timeout-in-simulation)). I fixed this by increasing the timeout from 60 seconds to 2.5 mins.
* Any call from a signer wasn't being routed through our provider proxy, so those calls were particularly prone to rate limits. They're now routed through the proxy.
* The backoff period was denominated in milliseconds, when it should've been denominated in seconds (oof)
* An obscure bug that was made a rate limit possible in the proxy. More details in a comment