### PR TITLE
fix(pg): Resolve eth mainnet simulation failure

### DIFF
--- a/packages/plugins/test/mocha/common.ts
+++ b/packages/plugins/test/mocha/common.ts
@@ -137,7 +137,7 @@ export const startForkedAnvilNodes = async (chainIds: Array<bigint>) => {
     exec(`anvil --fork-url ${forkUrl} --port ${getAnvilPort(chainId)} &`)
   }
 
-  await sleep(3000)
+  await sleep(10000)
 }
 
 export const killAnvilNodes = async (chainIds: Array<bigint>) => {


### PR DESCRIPTION
## Purpose
Resolves an issue where one of the simulation tests occasionally fails due to the fork starting slower than usual.