### PR TITLE
fix(core): Remove use of isVerified during contract verification

### DIFF
--- a/.changeset/eighty-tigers-teach.md
+++ b/.changeset/eighty-tigers-teach.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/core': patch
+---
+
+Do not use isVerified at all

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -237,8 +237,7 @@ export const attemptVerification = async (
     )
     guid = response.message
   } catch (err) {
-    const verified = await etherscan.isVerified(address)
-    if (verified) {
+    if ((err.message as string).toLowerCase().includes('already verified')) {
       console.log(
         `The contract ${address} has already been verified on Etherscan:\n${contractURL}`
       )


### PR DESCRIPTION
## Purpose
Removes the use of `isVerified()` during the contract verification in favor of matching on the string `already verified` [documented here](https://docs.etherscan.io/contract-verification/common-verification-errors#source-code-already-verified). This also works on Blockscout.