### PR TITLE
fix(ct): Update hard-coded Merkle leaf gas value on Moonbeam

### DIFF
--- a/.changeset/friendly-rivers-hear.md
+++ b/.changeset/friendly-rivers-hear.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Update hard-coded Merkle leaf gas value on Moonbeam

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -19,9 +19,11 @@ export const calculateActionLeafGasForMoonbeam = (
   access: ParsedAccountAccess
 ): string => {
   // This is the maximum Merkle leaf gas size that fits in a batch on these networks. (The max batch
-  // size is 12M, and there's a buffer applied to 10,896,000 before we check whether it fits in a
-  // batch).
-  return (10_896_000).toString()
+  // size is 12M, and there's a buffer applied to the Merkle leaf's gas before we check whether it fits in a
+  // batch). It's possible to exceed the max batch size if the transaction's calldata is extremely large,
+  // but that's unlikely to happen. We were able to deploy a very large contract (Mean Finance's DCAHub)
+  // with this Merkle leaf gas value.
+  return (10_500_000).toString()
 }
 
 export type ExplorerName = 'Blockscout' | 'Etherscan'


### PR DESCRIPTION
Previously, we were using a hard-coded Merkle leaf gas value on Moonbeam that was too high. I discovered this when attempting to deploy Mean Finance's `DCAHub`, which caused our batching logic to throw an error because it couldn't fit the corresponding `EXECUTE` leaf into a batch size of 1. This happened because `estimateGasViaManagedService` adds gas in relation to the length of the transaction's calldata. Since the transaction to deploy the `DCAHub` has a lot of calldata, the `estimateGasViaManagedService` function returned an estimated value that was 30k greater than the max batch size, which is 12 million.

This PR fixes the issue by decreasing the Merkle leaf gas value by ~300k. I successfully used the Deploy CLI command to deploy the `DCAHub` on Moonbase Alpha using this new Merkle leaf gas value.
The transaction used ~9.46M gas total, which is comfortably less than the new Merkle leaf gas value of 10.5 million. Here's the [transaction receipt](https://moonbase.moonscan.io/tx/0x2d7539a6dc48253605b1d3804a08fb740748be03e29742e02387f9fb44d1acfe) that deployed the `DCAHub`.

Note: See [this comment in Linear](https://linear.app/chugsplash/issue/CHU-742/improve-moonbeam-merkle-leaf-gas-heuristic#comment-cac69b76) for the latest status on the Moonbeam gas calculation logic.