### PR TITLE
fix(pg): throw an error if contracts are above the size limit

### DIFF
--- a/.changeset/curly-rules-boil.md
+++ b/.changeset/curly-rules-boil.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Throw an error if contracts are above the size limit

--- a/packages/contracts/contracts/foundry/Sphinx.sol
+++ b/packages/contracts/contracts/foundry/Sphinx.sol
@@ -250,6 +250,13 @@ abstract contract Sphinx {
         // the delegatecall in our error message.
         require(success, "Sphinx: Deployment script failed.");
         Vm.AccountAccess[] memory accesses = vm.stopAndReturnStateDiff();
+        // Set the `deployedCode` field for each AccountAccess of kind `Create`. There may be a bug
+        // in Foundry that causes this field to not always be populated.
+        for (uint256 i = 0; i < accesses.length; i++) {
+            if (accesses[i].kind == VmSafe.AccountAccessKind.Create) {
+                accesses[i].deployedCode = accesses[i].account.code;
+            }
+        }
 
         // We have to copy fundsRequestedForSafe and safeStartingBalance into deploymentInfo before
         // calling vm.revertTo because that cheatcode will clear the state variables.

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -42,3 +42,5 @@ export const EXECUTION_LOCK_TIME = 15 * 60
 
 export const RECOMMENDED_REMAPPING =
   '@sphinx-labs/contracts/=lib/sphinx/packages/contracts/contracts/foundry'
+
+export const MAX_CONTRACT_SIZE_LIMIT = 24576

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -35,6 +35,7 @@ import {
   recursivelyConvertResult,
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
   CreateCallArtifact,
+  MAX_CONTRACT_SIZE_LIMIT,
 } from '@sphinx-labs/contracts'
 
 import {
@@ -1707,6 +1708,15 @@ export const isPublicAsyncMethod = (
   }
 
   return false
+}
+
+/**
+ * Returns true if the given bytecode exceeds the contract size size limit as defined by:
+ * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md
+ */
+export const exceedsContractSizeLimit = (deployedBytecode: string): boolean => {
+  const bytesLength = remove0x(deployedBytecode).length / 2
+  return bytesLength > MAX_CONTRACT_SIZE_LIMIT
 }
 
 export const sphinxCoreUtils = { sleep, callWithTimeout, isPublicAsyncMethod }

--- a/packages/plugins/contracts/test/MyContracts.sol
+++ b/packages/plugins/contracts/test/MyContracts.sol
@@ -5,6 +5,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { Governor } from "@openzeppelin/contracts/governance/Governor.sol";
+import { SphinxUtils } from "@sphinx-labs/contracts/contracts/foundry/SphinxUtils.sol";
 
 struct TopLevelStruct {
     int256 a;
@@ -200,3 +201,5 @@ contract MyImmutableContract {
         return myFirstImmutable + uint256(mySecondImmutable);
     }
 }
+
+contract ExceedsContractMaxSizeLimit is SphinxUtils {}

--- a/packages/plugins/src/cli/deploy.ts
+++ b/packages/plugins/src/cli/deploy.ts
@@ -52,6 +52,7 @@ import {
   getSphinxConfigFromScript,
   parseScriptFunctionCalldata,
   readInterface,
+  assertContractSizeLimitNotExceeded,
   writeSystemContracts,
 } from '../foundry/utils'
 import { getFoundryToml } from '../foundry/options'
@@ -302,6 +303,11 @@ export const deploy = async (
   )
   const { configArtifacts, buildInfos } = await getConfigArtifacts(
     initCodeWithArgsArray
+  )
+
+  assertContractSizeLimitNotExceeded(
+    deploymentInfo.accountAccesses,
+    configArtifacts
   )
 
   await sphinxContext.assertNoLinkedLibraries(

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -43,6 +43,7 @@ import {
   assertValidVersions,
   validateProposalNetworks,
   parseScriptFunctionCalldata,
+  assertContractSizeLimitNotExceeded,
 } from '../../foundry/utils'
 import { SphinxContext } from '../context'
 import { FoundryToml } from '../../foundry/types'
@@ -175,6 +176,13 @@ export const buildNetworkConfigArray: BuildNetworkConfigArray = async (
 
   const { configArtifacts, buildInfos } = await getConfigArtifacts(
     initCodeWithArgsArray
+  )
+
+  collected.forEach(({ deploymentInfo }) =>
+    assertContractSizeLimitNotExceeded(
+      deploymentInfo.accountAccesses,
+      configArtifacts
+    )
   )
 
   await sphinxContext.assertNoLinkedLibraries(

--- a/packages/plugins/src/error-messages.ts
+++ b/packages/plugins/src/error-messages.ts
@@ -1,0 +1,22 @@
+export const contractsExceedSizeLimitErrorMessage = (
+  contracts: Array<{ address: string; fullyQualifiedName?: string }>
+): string => {
+  const contractLines = contracts
+    .map((contract) => {
+      let line = `- `
+      if (contract.fullyQualifiedName) {
+        line += `${contract.fullyQualifiedName} at `
+      }
+      line += `${contract.address}`
+      if (!contract.fullyQualifiedName) {
+        line += ' (unlabeled)'
+      }
+      return line
+    })
+    .join('\n')
+
+  return (
+    `The following contracts are over the contract size limit (24,576 bytes), which means they\n` +
+    `cannot be deployed on live networks:\n${contractLines}`
+  )
+}

--- a/packages/plugins/test/mocha/dummy.ts
+++ b/packages/plugins/test/mocha/dummy.ts
@@ -1,4 +1,9 @@
-import { Operation, SphinxMerkleTree } from '@sphinx-labs/contracts'
+import {
+  AccountAccess,
+  AccountAccessKind,
+  Operation,
+  SphinxMerkleTree,
+} from '@sphinx-labs/contracts'
 import {
   ActionInputType,
   BuildInfo,
@@ -338,5 +343,25 @@ export const getDummyDeployment = (): Deployment => {
     deploymentConfig: getDummyDeploymentConfig(),
     networkName: 'dummyNetwork',
     treeSigners: [],
+  }
+}
+
+export const getDummyAccountAccess = (): AccountAccess => {
+  return {
+    chainInfo: {
+      forkId: '0x1',
+      chainId: '0x3',
+    },
+    kind: AccountAccessKind.Balance,
+    account: '0xAccount',
+    accessor: '0xAccessor',
+    initialized: true,
+    oldBalance: '1000',
+    newBalance: '1500',
+    deployedCode: '0xCode',
+    value: '500',
+    data: '0xData',
+    reverted: false,
+    storageAccesses: [],
   }
 }

--- a/packages/plugins/test/mocha/error-messages.spec.ts
+++ b/packages/plugins/test/mocha/error-messages.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai'
+
+import { contractsExceedSizeLimitErrorMessage } from '../../src/error-messages'
+
+describe('Error Messages', () => {
+  it('contractsExceedSizeLimitErrorMessage', () => {
+    const contracts = [
+      {
+        address: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        fullyQualifiedName: 'contracts/ExampleContract.sol:ExampleContract',
+      },
+      { address: '0x1234567890ABCDEF1234567890ABCDEF12345678' }, // Unlabeled
+    ]
+    // eslint-disable-next-line prettier/prettier
+    const expectedMessage =
+`The following contracts are over the contract size limit (24,576 bytes), which means they
+cannot be deployed on live networks:
+- contracts/ExampleContract.sol:ExampleContract at 0xABCDEF1234567890ABCDEF1234567890ABCDEF12
+- 0x1234567890ABCDEF1234567890ABCDEF12345678 (unlabeled)`
+
+    const actualMessage = contractsExceedSizeLimitErrorMessage(contracts)
+
+    expect(actualMessage).to.equal(expectedMessage)
+  })
+})

--- a/packages/plugins/test/mocha/fake.ts
+++ b/packages/plugins/test/mocha/fake.ts
@@ -6,8 +6,10 @@ import {
   SphinxTransactionReceipt,
 } from '@sphinx-labs/core'
 import {
+  AccountAccessKind,
   ContractArtifact,
   Operation,
+  ParsedAccountAccess,
   SphinxModuleABI,
 } from '@sphinx-labs/contracts'
 import { EventFragment, ethers } from 'ethers'
@@ -15,6 +17,7 @@ import { EventFragment, ethers } from 'ethers'
 import {
   dummyBuildInfoId,
   dummyModuleAddress,
+  getDummyAccountAccess,
   getDummyBuildInfos,
   getDummyCompilerInput,
   getDummyEventLog,
@@ -143,5 +146,24 @@ export const getFakeDeploymentConfig = async (
     buildInfos: getDummyBuildInfos(),
     inputs: [compilerInput],
     version: '0',
+  }
+}
+
+export const getFakeParsedAccountAccess = (fields: {
+  kind: AccountAccessKind
+  data: string
+  account: string
+  deployedCode: string
+}): ParsedAccountAccess => {
+  const { kind, data, account, deployedCode } = fields
+  const root = getDummyAccountAccess()
+  root.kind = kind
+  root.data = data
+  root.account = account
+  root.deployedCode = deployedCode
+
+  return {
+    root,
+    nested: [],
   }
 }


### PR DESCRIPTION
Multiple users have run into this issue, most recently 0xBased today. See [this ticket](https://linear.app/chugsplash/issue/CHU-389/throw-a-helpful-error-if-contracts-are-too-large) for context.