### PR TITLE
maint(demo): bump timeout for demo tests

### DIFF
--- a/.changeset/gorgeous-tools-smoke.md
+++ b/.changeset/gorgeous-tools-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/demo': patch
+---
+
+Bump timeout for demo tests

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -14,7 +14,7 @@
     "build:contracts": "forge build",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
     "test:coverage": "apt install lsof && yarn test",
-    "test": "npx mocha --require ts-node/register --timeout 500000 'test/**/*.ts'",
+    "test": "npx mocha --require ts-node/register --timeout 800000 'test/**/*.ts'",
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:check": "yarn lint:ts:check",
     "lint:fix": "yarn lint:ts:fix",


### PR DESCRIPTION
The demo tests are roughly 2 minutes slower after #1628 because each compilation in the test case called "Compiles with viaIR and optimizer enabled" is five seconds slower due to the addition of `SphinxUtils`