### PR TITLE
fix(pg): Lower hardcoded merkle leaf gas on Pangolin

### DIFF
--- a/.changeset/violet-numbers-sin.md
+++ b/.changeset/violet-numbers-sin.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+---
+
+Lower hardcoded merkle leaf gas on Pangolin

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -1178,6 +1178,6 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
-    hardcodedMerkleLeafGas: (14_000_000).toString(),
+    hardcodedMerkleLeafGas: (11200000).toString(),
   },
 ]

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -140,6 +140,10 @@ export const calculateMerkleLeafGas = (chainId: bigint, foundryGas: string) => {
   const network = SPHINX_NETWORKS.find((n) => n.chainId === chainId)
 
   if (network?.hardcodedMerkleLeafGas) {
+    if (BigInt(foundryGas) > BigInt(network?.hardcodedMerkleLeafGas)) {
+      throw new Error('Transaction too large to be executed')
+    }
+
     return network.hardcodedMerkleLeafGas
   } else {
     return foundryGas

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1351,7 +1351,7 @@ export const getMaxGasLimit = (blockGasLimit: bigint): bigint => {
   // million will have a max batch size of 5.68 million (= 80% * 7.1 million), which is too low.
   if (blockGasLimit <= BigInt(8_500_000)) {
     return blockGasLimit
-  } else if (blockGasLimit <= BigInt(13_500_000)) {
+  } else if (blockGasLimit <= BigInt(20_000_000)) {
     return (blockGasLimit * BigInt(8)) / BigInt(10)
   }
 

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -496,8 +496,8 @@ describe('Utils', () => {
       expect(getMaxGasLimit(blockGasLimit)).to.equal(expected)
     })
 
-    it('returns 50% of the blockGasLimit if it is greater than 13,500,000', () => {
-      const blockGasLimit = BigInt(14_000_000)
+    it('returns 50% of the blockGasLimit if it is greater than 20,000,000', () => {
+      const blockGasLimit = BigInt(21_000_000)
       const expected = blockGasLimit / BigInt(2)
       expect(getMaxGasLimit(blockGasLimit)).to.equal(expected)
     })
@@ -509,8 +509,8 @@ describe('Utils', () => {
           expected: BigInt(8_500_000),
         },
         {
-          input: BigInt(13_500_000),
-          expected: (BigInt(13_500_000) * BigInt(8)) / BigInt(10),
+          input: BigInt(20_000_000),
+          expected: (BigInt(20_000_000) * BigInt(8)) / BigInt(10),
         },
       ]
       testCases.forEach(({ input, expected }) => {


### PR DESCRIPTION
## Purpose
Fixes an issue where the hardcoded Merkle leaf gas on Pangolin was greater than the maximum batch on Pangolin. This is a temporary solution. 

I think we should discuss and then implement a better solution that takes into account the variable batch size that is set using the `getMaxGasLimit` function. 