### PR TITLE
fix(pg): disable polygon zkevm action transaction batching

### DIFF
--- a/.changeset/slow-cheetahs-perform.md
+++ b/.changeset/slow-cheetahs-perform.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Disable action batching on Polygon ZKEVM

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -30,6 +30,7 @@ export type SupportedNetwork = {
   legacyTx: boolean
   actionGasLimitBuffer: boolean
   eip2028: boolean
+  actionTransactionBatching: boolean
   rollupStack?: {
     provider: RollupProvider
     type: RollupType
@@ -94,6 +95,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'sepolia',
@@ -123,6 +125,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'optimism',
@@ -152,6 +155,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'optimism_sepolia',
@@ -181,6 +185,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'arbitrum',
@@ -204,6 +209,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'arbitrum_sepolia',
@@ -227,6 +233,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'polygon',
@@ -250,6 +257,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'polygon_mumbai',
@@ -273,6 +281,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'bnb',
@@ -296,6 +305,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'bnb_testnet',
@@ -319,6 +329,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'gnosis',
@@ -348,6 +359,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'gnosis_chiado',
@@ -372,6 +384,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'linea',
@@ -395,6 +408,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'linea_sepolia',
@@ -418,6 +432,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'polygon_zkevm',
@@ -448,6 +463,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'polygon_zkevm_cardona',
@@ -471,6 +487,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'avalanche',
@@ -494,6 +511,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'avalanche_fuji',
@@ -517,6 +535,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'fantom',
@@ -540,6 +559,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'fantom_testnet',
@@ -557,6 +577,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'base',
@@ -586,6 +607,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'base_sepolia',
@@ -615,6 +637,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'celo',
@@ -638,6 +661,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'celo_alfajores',
@@ -661,6 +685,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'moonriver',
@@ -685,6 +710,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     hardcodedMerkleLeafGas: (10_500_000).toString(),
+    actionTransactionBatching: false,
   },
   {
     name: 'moonbeam',
@@ -709,6 +735,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     hardcodedMerkleLeafGas: (10_500_000).toString(),
+    actionTransactionBatching: false,
   },
   {
     name: 'moonbase_alpha',
@@ -733,6 +760,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     hardcodedMerkleLeafGas: (10_500_000).toString(),
+    actionTransactionBatching: false,
   },
   {
     name: 'fuse',
@@ -757,6 +785,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'evmos',
@@ -774,6 +803,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'evmos_testnet',
@@ -791,6 +821,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'kava',
@@ -816,6 +847,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'kava_testnet',
@@ -833,6 +865,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'scroll',
@@ -863,6 +896,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'scroll_sepolia',
@@ -886,6 +920,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'rootstock',
@@ -910,6 +945,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: true,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'rootstock_testnet',
@@ -934,6 +970,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     queryFilterBlockLimit: 2000,
     actionGasLimitBuffer: true,
     eip2028: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'zora',
@@ -963,6 +1000,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
       provider: 'Conduit',
       type: 'OP Stack',
     },
+    actionTransactionBatching: true,
   },
   {
     name: 'zora_sepolia',
@@ -992,6 +1030,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
       provider: 'Conduit',
       type: 'OP Stack',
     },
+    actionTransactionBatching: true,
   },
   {
     name: 'rari',
@@ -1021,6 +1060,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
       provider: 'Caldera',
       type: 'Arbitrum',
     },
+    actionTransactionBatching: false,
   },
   {
     name: 'rari_sepolia',
@@ -1050,6 +1090,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
       provider: 'Caldera',
       type: 'Arbitrum',
     },
+    actionTransactionBatching: false,
   },
   {
     name: 'blast_sepolia',
@@ -1073,6 +1114,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'blast',
@@ -1096,6 +1138,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'taiko_katla',
@@ -1113,6 +1156,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'mode_sepolia',
@@ -1137,6 +1181,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'mode',
@@ -1161,6 +1206,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
+    actionTransactionBatching: true,
   },
   {
     name: 'darwinia_pangolin',
@@ -1179,5 +1225,6 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     hardcodedMerkleLeafGas: (11200000).toString(),
+    actionTransactionBatching: false,
   },
 ]

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -609,9 +609,10 @@ const makeExecutionArtifact = async (
   merkleRoot: string,
   provider: SphinxJsonRpcProvider
 ): Promise<ExecutionArtifact> => {
-  const ethersResponses = await Promise.all(
-    receipts.map((rcpt) => provider.getTransaction(rcpt.hash))
-  )
+  const ethersResponses: (ethers.TransactionResponse | null)[] = []
+  for (const rcpt of receipts) {
+    ethersResponses.push(await provider.getTransaction(rcpt.hash))
+  }
 
   const responses = ethersResponses.map((ethersResponse) =>
     convertEthersTransactionResponse(ethersResponse, networkConfig.chainId)

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -103,6 +103,18 @@ export const isSupportedProductionNetwork = (chainId: bigint): boolean => {
   }
 }
 
+export const isActionTransactionBatchingEnabled = (
+  chainId: bigint
+): boolean => {
+  const network = SPHINX_NETWORKS.find((n) => n.chainId === chainId)
+
+  if (network) {
+    return network.actionTransactionBatching
+  } else {
+    return false
+  }
+}
+
 // Warning: Not supported on Anvil since this is expected to only be used on live networks
 export const fetchDripSizeForNetwork = (chainId: bigint) => {
   const network = SPHINX_NETWORKS.find((n) => n.chainId === chainId)


### PR DESCRIPTION
## Purpose
- Adds logic to allow disabling action batching during the execution process.
- Fixes an issue where artifact generation could fail for deployments that involved a large number of transactions. 
- Disables batching on the following networks: Polygon zkevm (and testnet), Linea (and testnet), Moonbeam, Moonriver, Moonbase Alpha, Scroll (and testnet), Rootstock (and testnet), Rari (and testnet), Darwinia Pangolin

### These networks were chosen because they fall into these categories:
- Is a ZK Rollup
- Is in the list of networks on [CHU-861](https://linear.app/chugsplash/issue/CHU-861/investigate-calldata-length-restrictions-on-certain-networks) where the calldata size is a problem
- Is a network where we use a hardcoded merkle leaf gas limit