### PR TITLE
fix(ct): Remove depth field from Sphinx validate

### DIFF
--- a/.changeset/slimy-foxes-smell.md
+++ b/.changeset/slimy-foxes-smell.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+---
+
+Remove depth from Sphinx validate

--- a/packages/contracts/contracts/foundry/SphinxUtils.sol
+++ b/packages/contracts/contracts/foundry/SphinxUtils.sol
@@ -107,12 +107,6 @@ contract SphinxUtils is SphinxConstants {
             return false;
         }
 
-        // If the second access has a depth of 0, then the foundry version installed must not include
-        // the depth field, so we return false
-        if (accountAccesses[1].depth == 0) {
-            return false;
-        }
-
         // If the deployed code at the calculated address is incorrect, then return false.
         // This confirms the deterministic deployment proxy is in fact being used for the
         // internal simulation.

--- a/packages/contracts/test/SphinxUtils.t.sol
+++ b/packages/contracts/test/SphinxUtils.t.sol
@@ -139,53 +139,6 @@ contract SphinxUtils_Test is Test, SphinxUtils, SphinxTestUtils {
         assertEq(passedCheck, false);
     }
 
-    function test_sphinxCheckAccesses_fails_incorrect_depth() external {
-        address expectedAddress = vm.computeCreate2Address(
-            0,
-            keccak256(type(SphinxForkCheck).creationCode),
-            DETERMINISTIC_DEPLOYMENT_PROXY
-        );
-
-        Vm.AccountAccess[] memory accountAccesses = new Vm.AccountAccess[](2);
-        accountAccesses[0] = VmSafe.AccountAccess({
-            chainInfo: VmSafe.ChainInfo(0, 1),
-            kind: VmSafe.AccountAccessKind.Call,
-            account: address(DETERMINISTIC_DEPLOYMENT_PROXY),
-            accessor: address(this),
-            initialized: false,
-            oldBalance: 0,
-            newBalance: 0,
-            deployedCode: new bytes(0),
-            value: 0,
-            data: type(SphinxForkCheck).creationCode,
-            reverted: false,
-            storageAccesses: new Vm.StorageAccess[](0),
-            depth: 0
-        });
-        accountAccesses[1] = VmSafe.AccountAccess({
-            chainInfo: VmSafe.ChainInfo(0, 1),
-            kind: VmSafe.AccountAccessKind.Create,
-            account: address(expectedAddress),
-            accessor: DETERMINISTIC_DEPLOYMENT_PROXY,
-            initialized: false,
-            oldBalance: 0,
-            newBalance: 0,
-            deployedCode: "",
-            value: 0,
-            data: type(SphinxForkCheck).creationCode,
-            reverted: false,
-            storageAccesses: new Vm.StorageAccess[](0),
-            depth: 0
-        });
-
-        bool passedCheck = checkAccesses(
-            accountAccesses,
-            keccak256(type(SphinxForkCheck).creationCode),
-            keccak256(type(SphinxForkCheck).runtimeCode)
-        );
-        assertEq(passedCheck, false);
-    }
-
     function test_sphinxCheckAccesses_fails_incorrect_address() external {
         Vm.AccountAccess[] memory accountAccesses = new Vm.AccountAccess[](2);
         accountAccesses[0] = VmSafe.AccountAccess({


### PR DESCRIPTION
## Purpose
Removes the depth check from our validation function just in case [this PR is merged in Foundry](https://github.com/foundry-rs/foundry/pull/7632). 