### PR TITLE
feat(pg): Include rollup stack information on all relevant networks

### DIFF
--- a/.changeset/calm-wombats-cross.md
+++ b/.changeset/calm-wombats-cross.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Include rollup stack information for all relevant networks

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -63,8 +63,8 @@ export const SPHINX_LOCAL_NETWORKS: Array<SupportedLocalNetwork> = [
 ]
 
 export type NetworkType = 'Testnet' | 'Mainnet' | 'Local'
-type RollupProvider = 'Conduit' | 'Caldera'
-type RollupType = 'OP Stack' | 'Arbitrum'
+type RollupProvider = 'Conduit' | 'Caldera' | 'None'
+type RollupType = 'OP Stack' | 'Arbitrum' | 'Polygon CDK'
 
 export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
   {
@@ -156,6 +156,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'optimism_sepolia',
@@ -186,6 +190,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'arbitrum',
@@ -210,6 +218,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: false,
+    rollupStack: {
+      provider: 'None',
+      type: 'Arbitrum',
+    },
   },
   {
     name: 'arbitrum_sepolia',
@@ -234,6 +246,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: false,
+    rollupStack: {
+      provider: 'None',
+      type: 'Arbitrum',
+    },
   },
   {
     name: 'polygon',
@@ -458,6 +474,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: false,
+    rollupStack: {
+      provider: 'None',
+      type: 'Polygon CDK',
+    },
   },
   {
     name: 'polygon_zkevm_cardona',
@@ -482,6 +502,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: false,
+    rollupStack: {
+      provider: 'None',
+      type: 'Polygon CDK',
+    },
   },
   {
     name: 'avalanche',
@@ -602,6 +626,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'base_sepolia',
@@ -632,6 +660,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'celo',
@@ -1109,6 +1141,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'blast',
@@ -1133,6 +1169,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'None',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'taiko_katla',
@@ -1176,6 +1216,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'Conduit',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'mode',
@@ -1201,6 +1245,10 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionGasLimitBuffer: false,
     eip2028: true,
     actionTransactionBatching: true,
+    rollupStack: {
+      provider: 'Conduit',
+      type: 'OP Stack',
+    },
   },
   {
     name: 'darwinia_pangolin',

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -107,11 +107,10 @@ export type ContractInfo = {
 }
 
 export type EstimateGasTransactionData = {
-  to: string | null
+  to: string
   from: string
   data: string
   gasLimit: string
-  gasPrice: string
   value: string
   chainId: string
 }

--- a/packages/core/test/convert.spec.ts
+++ b/packages/core/test/convert.spec.ts
@@ -20,11 +20,6 @@ import {
   sleep,
 } from '../src'
 
-// We filter out app chains because we expect the mainnet test to cover them adequately
-const fetchNonRollupStackChains = () => {
-  return SPHINX_NETWORKS.filter((network) => network.rollupStack === undefined)
-}
-
 describe('Convert EthersJS Objects', () => {
   const anvilPrivateKey =
     '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
@@ -82,6 +77,14 @@ describe('Convert EthersJS Objects', () => {
       '0x6a869d63d8c722ed2a4ec2f9af48ec3486f954a46b8f00a0b2ee4411c95f3b78',
     59141: '0x2c9b7cd04f5db3b6ab923dc8e8eabc256f1a1d15467df6014609109965b763fa',
     43: '0x8562f6585e1a345e6a09a214799f0f99ec63e36182da54d32f6e099ae90fe86c',
+    1918988905:
+      '0xa4cf88a9a354eaa9d7aa25ecc607a43cfdc4f82762254d72c4daea5a5899e47a',
+    1380012617:
+      '0x3536ea6046dbcb7b4e85dee0ebff92bca33d53d9defe4684e74a487721e1fb3c',
+    999999999:
+      '0x6d4b16783da5e871ccec22624fdca23417d47197e16c801a72bb10dea93d0ed2',
+    7777777:
+      '0x7f8617c8a7d54ed192c6eff8d995c383594359ff7ceab9584747409df471599d',
   }
 
   before(async () => {
@@ -114,7 +117,7 @@ describe('Convert EthersJS Objects', () => {
 
   it('contains a hash for each live supported network', () => {
     expect(Object.values(transactionHashes).length).equals(
-      Object.values(fetchNonRollupStackChains()).length
+      SPHINX_NETWORKS.length
     )
   })
 

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -1089,7 +1089,6 @@ const toSphinxTransactionEstimatedGas = (
     from: response.from,
     data: response.data,
     gasLimit: response.gasLimit.toString(),
-    gasPrice: response.gasPrice.toString(),
     value: response.value.toString(),
     chainId: response.chainId.toString(),
   }


### PR DESCRIPTION
## Purpose
Fills in rollup stack information for relevant networks. This is useful for making sure our cost estimates are accurate on the website. 