### PR TITLE
fix(pg): Allow generating artifacts for deprecated networks

### DIFF
--- a/.changeset/heavy-coats-jam.md
+++ b/.changeset/heavy-coats-jam.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Allow generating artifacts for deprecated networks

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -1222,3 +1222,88 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     actionTransactionBatching: false,
   },
 ]
+
+export const DEPRECATED_SPHINX_NETWORKS = [
+  {
+    name: 'goerli',
+    chainId: BigInt(5),
+    blockexplorers: {
+      etherscan: {
+        browserURL: 'https://goerli.etherscan.io',
+        blockExplorer: 'Etherscan',
+      },
+      blockscout: undefined,
+    },
+  },
+  {
+    name: 'arbitrum_goerli',
+    chainId: BigInt(421613),
+    blockexplorers: {
+      etherscan: {
+        browserURL: 'https://goerli.arbiscan.io/',
+        blockExplorer: 'Etherscan',
+      },
+      blockscout: undefined,
+    },
+  },
+  {
+    name: 'optimism_goerli',
+    chainId: BigInt(420),
+    blockexplorers: {
+      etherscan: {
+        browserURL: 'https://goerli-optimism.etherscan.io/',
+        blockExplorer: 'Etherscan',
+      },
+      blockscout: undefined,
+    },
+  },
+  {
+    name: 'base_goerli',
+    chainId: BigInt(84531),
+    blockexplorers: {
+      etherscan: {
+        browserURL: 'https://goerli.basescan.org/',
+        blockExplorer: 'Etherscan',
+      },
+      blockscout: undefined,
+    },
+  },
+  {
+    name: 'oktc',
+    chainId: BigInt(66),
+    blockexplorers: {},
+  },
+  {
+    name: 'linea_goerli',
+    chainId: BigInt(59140),
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-goerli.lineascan.build/api',
+        browserURL: 'https://goerli.lineascan.build',
+        envKey: 'LINEA_ETHERSCAN_API_KEY',
+      },
+    },
+  },
+  {
+    name: 'polygon_zkevm_goerli',
+    chainId: BigInt(1442),
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet-zkevm.polygonscan.com/api',
+        browserURL: 'https://testnet-zkevm.polygonscan.com',
+        envKey: 'POLYGON_ZKEVM_ETHERSCAN_API_KEY',
+      },
+    },
+  },
+  {
+    name: 'polygon_mumbai',
+    chainId: BigInt(80001),
+    blockexplorers: {
+      etherscan: {
+        apiURL: 'https://api-testnet.polygonscan.com/api',
+        browserURL: 'https://mumbai.polygonscan.com/',
+        envKey: 'POLYGON_ETHERSCAN_API_KEY',
+      },
+    },
+  },
+]

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -2,6 +2,7 @@
 // Be careful when importing external dependencies to this file because they may cause issues when this file
 // is imported by the website.
 import {
+  DEPRECATED_SPHINX_NETWORKS,
   ExplorerName,
   SPHINX_LOCAL_NETWORKS,
   SPHINX_NETWORKS,
@@ -68,6 +69,18 @@ export const fetchSupportedNetworkByName = (
     return network
   } else {
     throw new Error(`Unsupported network name: ${networkName}`)
+  }
+}
+
+export const fetchNameForDeprecatedNetwork = (chainId: bigint) => {
+  const network = [...DEPRECATED_SPHINX_NETWORKS].find(
+    (n) => n.chainId === chainId
+  )
+
+  if (network) {
+    return network.name
+  } else {
+    return undefined
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -60,6 +60,7 @@ import { BuildInfo } from './languages/solidity/types'
 import {
   COMPILER_CONFIG_VERSION,
   LocalNetworkMetadata,
+  fetchNameForDeprecatedNetwork,
   fetchNameForNetwork,
 } from './networks'
 import { RelayProposal, StoreDeploymentConfig } from './types'
@@ -497,7 +498,11 @@ export const getNetworkNameDirectory = (
   chainId: string,
   executionMode: ExecutionMode
 ): string => {
-  const networkName = fetchNameForNetwork(BigInt(chainId))
+  const deprecatedNetworkName = fetchNameForDeprecatedNetwork(BigInt(chainId))
+  const networkName = deprecatedNetworkName
+    ? deprecatedNetworkName
+    : fetchNameForNetwork(BigInt(chainId))
+
   if (
     executionMode === ExecutionMode.LiveNetworkCLI ||
     executionMode === ExecutionMode.Platform


### PR DESCRIPTION
## Purpose
Fixes an issue where artifact generation fails if you have previously deployed on any networks that have been deprecated. 