### PR TITLE
fix(pg): Remove tx data from proposal request

### DIFF
--- a/.changeset/gorgeous-lobsters-tap.md
+++ b/.changeset/gorgeous-lobsters-tap.md
@@ -1,0 +1,7 @@
+---
+'@sphinx-labs/contracts': patch
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Disable transaction batching on Arbitrum Sepolia

--- a/.changeset/rare-toys-obey.md
+++ b/.changeset/rare-toys-obey.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/plugins': patch
+'@sphinx-labs/core': patch
+---
+
+Temporarily remove tx data from proposal requests

--- a/packages/contracts/src/networks.ts
+++ b/packages/contracts/src/networks.ts
@@ -209,7 +209,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
-    actionTransactionBatching: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'arbitrum_sepolia',
@@ -233,7 +233,7 @@ export const SPHINX_NETWORKS: Array<SupportedNetwork> = [
     legacyTx: false,
     actionGasLimitBuffer: false,
     eip2028: true,
-    actionTransactionBatching: true,
+    actionTransactionBatching: false,
   },
   {
     name: 'polygon',

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -151,7 +151,6 @@ export type NetworkGasEstimate = {
   chainId: number
   estimatedGas: string
   fundsRequested?: string
-  transactions?: Array<TransactionEstimatedGas>
 }
 
 /**

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -1164,10 +1164,7 @@ export const getNetworkGasEstimate: GetNetworkGasEstimate = async (
   const { transactions } = await simulate(deploymentConfig, chainId, rpcUrl)
 
   const provider = new SphinxJsonRpcProvider(rpcUrl)
-  const { estimatedGas, transactionsWithGasEstimates } = await getEstimatedGas(
-    transactions,
-    provider
-  )
+  const { estimatedGas } = await getEstimatedGas(transactions, provider)
 
   const networkConfig = fetchNetworkConfigFromDeploymentConfig(
     BigInt(chainId),
@@ -1177,7 +1174,6 @@ export const getNetworkGasEstimate: GetNetworkGasEstimate = async (
   return {
     chainId: Number(chainId),
     estimatedGas,
-    transactions: transactionsWithGasEstimates,
     fundsRequested: networkConfig.safeFundingRequest?.fundsRequested ?? '0',
   }
 }


### PR DESCRIPTION
## Purpose

### Removes the transaction data from the proposal request gas estimates
We still need this data to properly estimate the cost of deployments on OP stack networks, but we should not supply it this way via proposals because we can exceed the request size limit in extreme cases. I thought this was quite unlikely to occur, but this is what happened with Centrifudges deployment. I will need to reconsider how to go about estimating the deployment cost on OP stack chains without having this data immediately available in the proposal API endpoint. 

Note that this change is *not* required to unblock Centrifuge, I resolved their issue with a minor change on the website. This PR eliminates the possibility of it happening to anyone else. 

### Disables transaction batching on Arbitrum
As a precaution, I tested out deploying on the testnets of all the networks Centrifuge wants to deploy on. I found that the calldata size was an issue on Arbitrum, so I've temporarily disabled batching on the network to ensure their deployment is smooth. 

Since Arbitrum has an insanely high block gas limit, our system attempts to execute their entire deployment (~40 transactions and 12 contract deployments in a single massive transaction).