### PR TITLE
fix(pg): Pass through error if API response unexpected

### DIFF
--- a/.changeset/poor-bats-draw.md
+++ b/.changeset/poor-bats-draw.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Stop hiding API call error if response code unexpected

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -79,9 +79,7 @@ export const fetchDeploymentArtifacts = async (
         } else if (err.response.status === 404) {
           throw new Error(`No artifacts found for this project`)
         } else {
-          throw new Error(
-            `Unexpected response code, please report this to the developers`
-          )
+          throw err
         }
       } else {
         throw err

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -404,9 +404,7 @@ export const relayProposal: RelayProposal = async (
         `Internal server error. Please report this to the developers.`
       )
     } else {
-      throw new Error(
-        `Unexpected response code. Please report this to the developers.`
-      )
+      throw e
     }
   }
 }
@@ -440,9 +438,7 @@ export const storeDeploymentConfig: StoreDeploymentConfig = async (
             `Unauthorized, please check your API key and Org Id are correct`
           )
         } else {
-          throw new Error(
-            `Unexpected response code, please report this to the developers`
-          )
+          throw err
         }
       } else {
         throw err


### PR DESCRIPTION
## Purpose
Causes API errors to be passed through to the console if the response code is unexpected. This should help with debugging API-related issues that are hard to reproduce.