### PR TITLE
fix: `libraryVersion` quote slicing

### DIFF
--- a/.changeset/nine-ligers-approve.md
+++ b/.changeset/nine-ligers-approve.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Fix for library version error

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -1312,8 +1312,8 @@ export const assertValidVersions = async (
   )
 
   const libraryVersion = output.returns.libraryVersion.value
-    // The raw string is wrapped in two sets of quotes, so we remove the outer quotes here.
-    .slice(1, -1)
+    // If the version number contains any quotes we remove them
+    .replace(/"/g, '');
   const forkInstalled = output.returns.forkInstalled.value
 
   if (libraryVersion !== CONTRACTS_LIBRARY_VERSION) {


### PR DESCRIPTION
## Description
Instead of slicing into the `libraryVersion` string we now replace quotes, this makes it so if there are no quotes it doesn't remove/replace anything.

## Related Issue
#1732 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
New versions of foundry no longer have the version double quoted, this PR makes it so it works for both the older versions of foundry as well as the newer versions.

## How Has This Been Tested?
-

