### PR TITLE
fix(pg): no longer use `--json` and `--quiet` for forge scripts

### DIFF
--- a/.changeset/tricky-chefs-fail.md
+++ b/.changeset/tricky-chefs-fail.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Fix for `the argument '--quiet' cannot be used with '--json'`

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -785,12 +785,12 @@ export const getForgeScriptArgs = (
     ...args,
   ]
 
-  if (silent) {
-    forgeScriptArgs.push('--silent')
-  }
-
+  // In new versions of foundry the existence of the `--json` flag also implies `--silent`.
+  // So we only append the `silent` flag if `json` is false.
   if (json) {
     forgeScriptArgs.push('--json')
+  } else if (silent) {
+    forgeScriptArgs.push('--silent')
   }
 
   if (broadcast) {


### PR DESCRIPTION
## Motivation and Context
New versions of foundry do not allow the usage of both the `--json` and `--silent` flags. Using them both results in an error message. The `--silent` flag is now implied by the `--json` flag.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Using existing tests.
