### PR TITLE
ci: disable tests that rely on live networks and a hosted instance 

### DIFF
--- a/packages/core/test/convert.spec.ts
+++ b/packages/core/test/convert.spec.ts
@@ -171,7 +171,7 @@ describe('Convert EthersJS Objects', () => {
   })
 
   describe.skip('succeeds on live networks', () => {
-    before(function() {
+    before(function () {
       // Skip the tests if the environment variable `CIRCLE_BRANCH` is defined and does not equal
       // 'develop', which enforces that these tests only run in CI when the source branch is
       // 'develop'. These tests will also run on local machines because the `CIRCLE_BRANCH`

--- a/packages/core/test/convert.spec.ts
+++ b/packages/core/test/convert.spec.ts
@@ -113,7 +113,9 @@ describe('Convert EthersJS Objects', () => {
     }
 
     if (missingApiKey.length > 0) {
-      throw new Error(`Missing API key for:\n` + missingApiKey.join('\n'))
+      // TODO: Re-enable this error once we updated the networks to remove ones that have been deprecated.
+      // And re-enabled the tests for live networks.
+      // throw new Error(`Missing API key for:\n` + missingApiKey.join('\n'))
     }
   })
 

--- a/packages/core/test/convert.spec.ts
+++ b/packages/core/test/convert.spec.ts
@@ -170,8 +170,8 @@ describe('Convert EthersJS Objects', () => {
     })
   })
 
-  describe('succeeds on live networks', () => {
-    before(function () {
+  describe.skip('succeeds on live networks', () => {
+    before(function() {
       // Skip the tests if the environment variable `CIRCLE_BRANCH` is defined and does not equal
       // 'develop', which enforces that these tests only run in CI when the source branch is
       // 'develop'. These tests will also run on local machines because the `CIRCLE_BRANCH`

--- a/packages/demo/test/Solc.spec.ts
+++ b/packages/demo/test/Solc.spec.ts
@@ -23,7 +23,7 @@ const testDir = 'test'
 // representation compiler setting (i.e. `viaIR`). We test every supported solc version because
 // minor changes in solc can lead to "stack too deep" errors. See this post and cameel's response
 // for context: https://github.com/ethereum/solidity/issues/14082
-describe('Solidity Compiler', () => {
+describe.skip('Solidity Compiler', () => {
   let contractPath: string
   let scriptPath: string
   let testPath: string

--- a/packages/demo/test/init.spec.ts
+++ b/packages/demo/test/init.spec.ts
@@ -21,7 +21,7 @@ const srcDir = 'src'
 const scriptDir = 'script'
 const testDir = 'test'
 
-describe('Init CLI command', () => {
+describe.skip('Init CLI command', () => {
   let contractPath: string
   let scriptPath: string
   let testPath: string

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -787,6 +787,7 @@ export const getForgeScriptArgs = (
 
   // In new versions of foundry the existence of the `--json` flag also implies `--silent`.
   // So we only append the `silent` flag if `json` is false.
+  // TODO: Check what foundry version is being used locally, if its ^0.3.0 use the logic below, otherwise use the logic as we had it before.
   if (json) {
     forgeScriptArgs.push('--json')
   } else if (silent) {

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -1313,7 +1313,7 @@ export const assertValidVersions = async (
 
   const libraryVersion = output.returns.libraryVersion.value
     // If the version number contains any quotes we remove them
-    .replace(/"/g, '');
+    .replace(/"/g, '')
   const forkInstalled = output.returns.forkInstalled.value
 
   if (libraryVersion !== CONTRACTS_LIBRARY_VERSION) {

--- a/packages/plugins/test/mocha/cli/propose.spec.ts
+++ b/packages/plugins/test/mocha/cli/propose.spec.ts
@@ -29,7 +29,7 @@ const sepoliaRpcUrl = `http://127.0.0.1:42111`
 
 const allNetworkNames = ['ethereum', 'optimism', 'sepolia']
 
-describe('Propose CLI command', () => {
+describe.skip('Propose CLI command', () => {
   let originalEnv: NodeJS.ProcessEnv
 
   before(async () => {


### PR DESCRIPTION
## Description
Since there currently is no instance of the hosted platform and some testnets have been deprecated and thus no longer have available RPCs, we are disabling some tests that rely on these (for now).