### PR TITLE
fix: update broken link cli-quickstart.md

### DIFF
--- a/docs/cli-quickstart.md
+++ b/docs/cli-quickstart.md
@@ -27,7 +27,7 @@ In this guide, you'll create a sample project, propose it on the command line, a
 * You must have a running instance of the [Sphinx Platform](https://github.com/sphinx-labs/sphinx-platform/block/main/docs/local.md).
 * You must have a basic understanding of how to use Foundry and Forge scripts. Here are the relevant guides in the Foundry docs:
   * [Getting Started with Foundry](https://book.getfoundry.sh/getting-started/first-steps)
-  * [Writing Deployment Scripts with Foundry](https://book.getfoundry.sh/tutorials/solidity-scripting)
+  * [Writing Deployment Scripts with Foundry](https://book.getfoundry.sh/guides/scripting-with-solidity)
 * You must have an Alchemy API key, which you can get on [their website](https://www.alchemy.com/).
 * You must have an account that exists on live networks. This account will own your Gnosis Safe.
 * The following must be installed on your machine:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I fixes a broken link in the `cli-quickstart.md` file. The old link pointed to the deprecated Foundry documentation page for Solidity scripting (`tutorials/solidity-scripting`). It has been updated to the correct and current link: `guides/scripting-with-solidity`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please open an issue for it first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Type of change
<!--- Please delete options that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Contract Breaking Change (fix or feature that would cause the system to no longer work with contracts currently deployed on live networks)
- [x] Documentation update

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken links in documentation can confuse users and disrupt their workflow. This fix ensures that the link points to the correct and up-to-date resource for Solidity scripting in Foundry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Please describe any automated tests you've added to test your changes. -->
- Manually verified that the new link (`https://book.getfoundry.sh/guides/scripting-with-solidity`) is correct and functional.
