### PR TITLE
fix: remove `--no-commit` argument

### DIFF
--- a/.changeset/wicked-clouds-shave.md
+++ b/.changeset/wicked-clouds-shave.md
@@ -1,0 +1,5 @@
+---
+'@sphinx-labs/plugins': patch
+---
+
+Remove `--no-commit` foundry option as no commit is now the default and no longer supported as an argument

--- a/packages/plugins/src/cli/install/index.ts
+++ b/packages/plugins/src/cli/install/index.ts
@@ -10,9 +10,6 @@ const installWithUpdate = async (spinner: ora.Ora) => {
   const args = [
     'install',
     `sphinx-labs/sphinx@${CONTRACTS_LIBRARY_VERSION}`,
-    // We always use --no-commit here because it's necessary if the user has any files that have been changed, but not committed.
-    // This will almost always be the case during installation b/c the user first needs to install our CLI.
-    '--no-commit',
   ]
 
   // Check if the library is installed
@@ -77,7 +74,7 @@ export const handleInstall = async (spinner: ora.Ora) => {
   // Foundry doesn't consistently install our subdependency, so we make sure it's installed ourselves.
   // We should test this out later and remove if possible.
   execSync(
-    'cd lib/sphinx/packages/contracts && forge install --no-commit && cd ../../ && git restore packages/contracts/foundry.toml',
+    'cd lib/sphinx/packages/contracts && forge install && cd ../../ && git restore packages/contracts/foundry.toml',
     { stdio: 'ignore' }
   )
   spinner.succeed('Successfully installed Sphinx Solidity library')


### PR DESCRIPTION
This argument is no longer needed as no commit has become the default, additionally it now errors as the argument is not a valid option anymore.