### PR TITLE
Handle solc library placeholders in deployment configs

### DIFF
--- a/.changeset/fix-solc-library-placeholders.md
+++ b/.changeset/fix-solc-library-placeholders.md
@@ -1,0 +1,6 @@
+---
+'@sphinx-labs/core': patch
+'@sphinx-labs/plugins': patch
+---
+
+Handle unresolved solc library placeholders when proposing and verifying deployments.

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -22,6 +22,7 @@ import { getMinimumCompilerInput } from './languages/solidity/compiler'
 import {
   fetchNetworkConfigFromDeploymentConfig,
   formatSolcLongVersion,
+  getAbiEncodedConstructorArgs,
   isLiveNetwork,
   sleep,
 } from './utils'
@@ -69,9 +70,9 @@ export const verifySphinxConfig = async (
       // method works even if the `artifact.bytecode` contains externally linked library
       // placeholders or immutable variable placeholders, which are always the same length as the
       // real values.
-      const encodedConstructorArgs = ethers.dataSlice(
+      const encodedConstructorArgs = getAbiEncodedConstructorArgs(
         initCodeWithArgs,
-        ethers.dataLength(artifact.bytecode)
+        artifact.bytecode
       )
 
       const result = await attemptVerification(
@@ -131,9 +132,9 @@ export const verifyDeploymentWithRetries = async (
         // method works even if the `artifact.bytecode` contains externally linked library
         // placeholders or immutable variable placeholders, which are always the same length as the
         // real values.
-        const encodedConstructorArgs = ethers.dataSlice(
+        const encodedConstructorArgs = getAbiEncodedConstructorArgs(
           initCodeWithArgs,
-          ethers.dataLength(artifact.bytecode)
+          artifact.bytecode
         )
 
         const result = await attemptVerification(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1360,6 +1360,19 @@ export const getBytesLength = (hexString: string): number => {
 }
 
 /**
+ * Replace unresolved solc library placeholders with zero bytes.
+ *
+ * Solc emits placeholders like `__$<34 hex chars>$__` for unlinked libraries. The placeholders
+ * are the same length as an address, but they are not valid hex strings.
+ */
+export const zeroOutSolcLibraryPlaceholders = (value: string): string => {
+  return value.replace(
+    /__\$[0-9a-fA-F]{34}\$__/g,
+    remove0x(ethers.ZeroAddress)
+  )
+}
+
+/**
  * Replace library references in the `bytecode` with zeros. This function uses the `linkReferences`
  * to find the location of the library references.
  *
@@ -1408,7 +1421,7 @@ export const getAbiEncodedConstructorArgs = (
   initCodeWithArgs: string,
   artifactBytecode: string
 ): string => {
-  return ethers.dataSlice(initCodeWithArgs, ethers.dataLength(artifactBytecode))
+  return ethers.dataSlice(initCodeWithArgs, getBytesLength(artifactBytecode))
 }
 
 /**

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -11,7 +11,13 @@ import {
   formatSolcLongVersion,
 } from '../src/utils'
 import { ABI } from './common'
-import { callWithTimeout, getBytesLength, getMaxGasLimit } from '../dist'
+import {
+  callWithTimeout,
+  getAbiEncodedConstructorArgs,
+  getBytesLength,
+  getMaxGasLimit,
+  zeroOutSolcLibraryPlaceholders,
+} from '../dist'
 
 chai.use(sinonChai)
 
@@ -396,6 +402,25 @@ describe('Utils', () => {
       const version = '0.8.23+commit.f704f362.Darwin.appleclang'
       const formattedVersion = formatSolcLongVersion(version)
       expect(formattedVersion).to.equal('0.8.23+commit.f704f362')
+    })
+  })
+
+  describe('bytecode helpers', () => {
+    const placeholder = '__$6206bf2454c1dcfb641741f43bf52b101f$__'
+
+    it('zeroes unresolved solc library placeholders', () => {
+      expect(zeroOutSolcLibraryPlaceholders(`0x6000${placeholder}6001`)).equals(
+        `0x6000${'00'.repeat(20)}6001`
+      )
+    })
+
+    it('gets constructor args when artifact bytecode has library placeholders', () => {
+      const artifactBytecode = `0x6000${placeholder}6001`
+      const initCodeWithArgs = `0x6000${'12'.repeat(20)}6001deadbeef`
+
+      expect(
+        getAbiEncodedConstructorArgs(initCodeWithArgs, artifactBytecode)
+      ).equals('0xdeadbeef')
     })
   })
 

--- a/packages/plugins/src/cli/propose/index.ts
+++ b/packages/plugins/src/cli/propose/index.ts
@@ -17,6 +17,7 @@ import {
   makeDeploymentConfig,
   DEFAULT_CALL_DEPTH,
   syncSphinxLock,
+  zeroOutSolcLibraryPlaceholders,
 } from '@sphinx-labs/core'
 import ora from 'ora'
 import { blue } from 'chalk'
@@ -453,7 +454,9 @@ export const propose = async (
     },
   }
 
-  const deploymentConfigData = JSON.stringify(deploymentConfig, null, 2)
+  const deploymentConfigData = zeroOutSolcLibraryPlaceholders(
+    JSON.stringify(deploymentConfig, null, 2)
+  )
 
   if (isDryRun) {
     spinner.succeed(`Proposal dry run succeeded.`)


### PR DESCRIPTION
## Summary

- use placeholder-tolerant byte lengths when slicing constructor args
- zero out unresolved solc library placeholders before uploading deployment configs
- add regression coverage for bytecode helpers

## Tests

- `yarn workspace @sphinx-labs/contracts build:ts`
- `yarn workspace @sphinx-labs/core build:ts`
- `yarn workspace @sphinx-labs/plugins build:ts`
- `yarn workspace @sphinx-labs/core test --grep "bytecode helpers"`
